### PR TITLE
Implement unmatched_normal_ids

### DIFF
--- a/demo/config.yaml
+++ b/demo/config.yaml
@@ -5,9 +5,8 @@ lcr-modules:
         lcr-scripts: "../../lcr-scripts"
         root_output_dir: "results/"
         scratch_directory: "scratch/"
-        pairing_config:
-            capture:
-                unmatched_normal_id: "TCRBOA7-N-WEX"
+        unmatched_normal_ids:
+            capture--grch37: "TCRBOA7-N-WEX"
 
     star:
         inputs:

--- a/demo/data/TCRBOA7-ALT-T-WEX.bam
+++ b/demo/data/TCRBOA7-ALT-T-WEX.bam
@@ -1,0 +1,1 @@
+TCRBOA7-T-WEX.bam

--- a/demo/data/TCRBOA7-ALT-T-WEX.bam.bai
+++ b/demo/data/TCRBOA7-ALT-T-WEX.bam.bai
@@ -1,0 +1,1 @@
+TCRBOA7-T-WEX.bam.bai

--- a/demo/data/samples.tsv
+++ b/demo/data/samples.tsv
@@ -1,4 +1,5 @@
 sample_id	seq_type	patient_id	tissue_status	genome_build
 TCRBOA7-N-WEX	capture	TCRBOA7	normal	grch37
 TCRBOA7-T-WEX	capture	TCRBOA7	tumour	grch37
+TCRBOA7-ALT-T-WEX	capture	TCRBOA7-ALT	tumour	grch37
 TCRBOA7-T-RNA	mrna	TCRBOA7	tumour	grch37

--- a/docs/source/for_developers.rst
+++ b/docs/source/for_developers.rst
@@ -112,13 +112,13 @@ When you run the command listed in the :ref:`getting-started-dev` instructions, 
 
    Additional options will be added later, such as ``tumour_cohort`` and ``sample_cohort`` for level-3 modules (see :ref:`what-are-modules` for more details).
 
--  ``seq_type.genome``, ``seq_type.capture``, and ``seq_type.mrna``: Possible values are ``paired``, ``unpaired``, and ``omit``. These fields determine which sequencing data types (``seq_type``) are intended as input for the module and whether each ``seq_type`` is intended to be run in paired or unpaired mode. The fields correspond to whole genome, hybrid capture-based, and RNA sequencing, respectively. Select ``omit`` if a ``seq_type`` is not applicable for the module. 
+-  ``seq_type.genome``, ``seq_type.capture``, and ``seq_type.mrna``: Possible values are ``matched_only``, ``allow_unmatched``, ``no_normal``, and ``omit``. These fields determine which sequencing data types (``seq_type``) are intended as input for the module and whether each ``seq_type`` is intended to be run in paired or unpaired mode, and if in paired mode, whether to allow unmatched pairs. For more information on these modes, check out the documentation for the :py:func:`oncopipe.generate_pairs` function. Select ``omit`` if a ``seq_type`` is not applicable for the module. The fields correspond to whole genome, hybrid capture-based, and RNA sequencing, respectively.
 
    **Important**
 
-   - If you selected “sample” for ``module_run_per``, then you should use ``unpaired`` here. If this is a ``paired`` analysis, you should start over (cancel with Ctrl-C) and select ``tumour`` for ``module_run_per``. 
+   - If you selected ``sample`` for ``module_run_per``, then you should use ``no_normal`` here. If this is a paired analysis, you should start over (cancel with Ctrl-C) and select ``tumour`` for ``module_run_per``. 
    
-   - If you selected ``tumour`` for ``module_run_per``, you can select ``paired`` or ``unpaired`` depending on whether the module is meant to be run on tumour-normal pairs or not. 
+   - If you selected ``tumour`` for ``module_run_per``, you can select ``matched_only``, ``allow_unmatched``, or ``no_normal`` depending on whether the module is meant to be run on only matched tumour-normal pairs, on potentially unmatched tumour-normal pairs, or on tumours only. 
 
 Module Description
 ==================
@@ -666,8 +666,6 @@ Here's a brief description of each of the options that go into a ``pairing_confi
 - ``run_paired_tumours``: Possible values are ``True`` or ``False``. This option determines whether to run paired tumours. Setting this to ``False`` is useful for naturally unpaired or tumour-only analyses (*e.g.* for RNA-seq), which is normally done while setting ``run_paired_tumours_as_unpaired`` to True in case there are any paired tumours.
 
 - ``run_unpaired_tumours_with``: Possible values are ``None``, ``"unmatched_normal"``, or ``"no_normal"``. This option determines what to pair with unpaired tumours. Specifying ``None`` means that unpaired tumours will be skipped for the given module. This option cannot be set to ``None`` if ``run_paired_tumours_as_unpaired`` is ``True``. Specifying ``"unmatched_normal"`` means that unpaired tumours will be run by being paired with the unmatched normal sample given by ``unmatched_normal_id`` (see below). Specifying ``"no_normal"`` means that unpaired tumours will be run without a normal sample. Note that modules need to be specifically configured to be run in paired and/or unpaired mode, since the commands of the underlying tools probably need to be tailored accordingly.
-
-- ``unmatched_normal_id``: This option must be set to a sample identifier (``sample_id``) that exists in the :ref:`sample-table`. This option determines which normal sample will be used with unpaired tumours when ``run_unpaired_tumours_with`` is set to ``"unmatched_normal"``. This is only required if you have unpaired tumour samples, even if ``run_unpaired_tumours_with`` is set to ``"unmatched_normal"``. 
 
 - ``run_paired_tumours_as_unpaired``: Possible values are ``True`` or ``False``. This option determines whether paired tumours should be run as unpaired (*i.e.* separate from their matched normal sample). This is useful for benchmarking purposes or preventing unwanted paired analyses (*e.g.* in RNA-seq analyses intended to be tumour-only).
 

--- a/docs/source/for_users.rst
+++ b/docs/source/for_users.rst
@@ -50,7 +50,7 @@ Getting Started
    | TCRBOA7-T-RNA | mrna     | TCRBOA7    | tumour        | grch37       |
    +---------------+----------+------------+---------------+--------------+
 
-6. Add the :ref:`lcr-modules-configuration` to your project configuration YAML file (*e.g.* ``config.yaml``). If you have unpaired tumour samples, you will need to add a ``pairing_config``. Check out :ref:`handling-unpaired-tumours` section for more information and :ref:`within-the-configuration-file` for an example of how this is done.
+6. Add the :ref:`lcr-modules-configuration` to your project configuration YAML file (*e.g.* ``config.yaml``). If you have unpaired tumour samples, you will need to add a ``unmatched_normal_ids`` section. Check out :ref:`handling-unpaired-tumours` section for more information and :ref:`within-the-configuration-file` for an example of how this is done.
 
    .. code:: yaml
 
@@ -303,7 +303,7 @@ Common Shared Configuration Fields
 
 - ``scratch_directory``: This field specifies the directory where large intermediate files can be written without worry of running out of space or clogging snapshots/backups. If set to ``null``, the files will be output locally.
 
-- ``pairing_config``: This field is optional, but it's useful for specifying the normal samples to use in paired analyses with unpaired tumours. See :ref:`handling-unpaired-tumours` for more details and :ref:`updating-configuration-values` for an example configuration file where this is provided.
+- ``unmatched_normal_ids``: This field is optional, but it's useful for specifying the normal samples to use in paired analyses with unpaired tumours. See :ref:`handling-unpaired-tumours` for more details and :ref:`updating-configuration-values` for an example configuration file where this is provided.
 
 .. _handling-unpaired-tumours:
 
@@ -312,7 +312,15 @@ Handling Unpaired Tumours
 
 Each module has a pairing configuration (``pairing_config``) in their default configuration file. This ``pairing_config`` dictates which sequencing data types (``seq_type``) are supported by the module, whether the module runs in paired or unpaired mode for each ``seq_type``, and if so, how it performs these analyses for each ``seq_type``. This information is ultimately used by the :py:func:`oncopipe.generate_runs_for_patient` function when producing (or not) tumour-normal pairs. If you want to learn more, check out the :ref:`pairing-configuration` section in the developer documentation. 
 
-That said, the user doesn't need to worry about the ``pairing_config`` unless they have unpaired tumour samples or they wish to configure modules for new sequencing data types (``seq_type``). If they have unpaired tumours, for each ``seq_type``, they need to specify which normal sample to use for paired analyses where an unmatched normal sample will be used instead of a matched normal sample. This is done by providing values for ``unmatched_normal_id``, as demonstrated in the :ref:`within-the-configuration-file` section. 
+That said, the user doesn't need to worry about the ``pairing_config`` unless they have unpaired tumour samples or they wish to configure modules for new sequencing data types (``seq_type``). If they have unpaired tumours, they will need to specify the normal sample IDs to use for each ``seq_type`` and ``genome_build``. This is done using the ``unmatched_normal_ids`` key, as demonstrated in the :ref:`within-the-configuration-file` section. Briefly, the keys under ``unmatched_normal_ids`` take on the form ``<seq_type>--<genome_build>``, and the values are the sample IDs. Normally, ``unmatched_normal_ids`` is set under ``_shared`` such that this configuration is inherited by all modules, but it can also be provided at the module level if some modules should use different unmatched normal samples. 
+
+.. code:: yaml
+
+   lcr-modules:
+      _shared:
+         # [...]
+         unmatched_normal_ids:
+            capture--grch37: "TCRBOA7-N-WEX"
 
 If the user wants to configure new sequencing data types, they should check out the :ref:`configuring-new-seqtypes` section. 
 
@@ -336,7 +344,7 @@ One of the main limitations of this approach is that you are restricted to value
 
    The value ``null`` is parsed as ``None`` in Python. If you provide the value ``None`` in the YAML file, it will be parsed as the string ``"None"``.
 
-The example YAML file below is taken from the `Demo Configuration`_. You can see that it includes a ``pairing_config`` under ``_shared`` to indicate which normal samples to use for unpaired tumours for paired analyses (see :ref:`handling-unpaired-tumours`). It also updates a number of configuration values for the ``star`` and ``manta`` modules. All of these fields contain ``__UPDATE__`` in the modules' respective default configuration file. The only exception is the ``scratch_subdirectories`` field for the ``star`` module, which was updated here to include the ``"mark_dups"`` subdirectory such that the final BAM files from the module are also stored in the scratch directory.
+The example YAML file below is taken from the `Demo Configuration`_. You can see that it includes ``unmatched_normal_ids`` under ``_shared`` to indicate which normal samples to use for unpaired tumours for paired analyses (see :ref:`handling-unpaired-tumours`). It also updates a number of configuration values for the ``star`` and ``manta`` modules. All of these fields contain ``__UPDATE__`` in the modules' respective default configuration file. The only exception is the ``scratch_subdirectories`` field for the ``star`` module, which was updated here to include the ``"mark_dups"`` subdirectory such that the final BAM files from the module are also stored in the scratch directory.
 
 .. code:: yaml
 
@@ -348,9 +356,8 @@ The example YAML file below is taken from the `Demo Configuration`_. You can see
          lcr-scripts: "../../lcr-scripts"
          root_output_dir: "results/"
          scratch_directory: "scratch/"
-         pairing_config:
-            capture:
-                  unmatched_normal_id: "TCRBOA7-N-WEX"
+         unmatched_normal_ids:
+            capture--grch37: "TCRBOA7-N-WEX"
 
       star:
          inputs:
@@ -376,10 +383,8 @@ The main drawback of this approach is that it can be rather verbose, not very el
 
 .. code:: python
 
-   config["lcr-modules"]["_shared"]["pairing_config"] = {
-      "capture": {
-         "unmatched_normal_id": "TCRBOA7-N-WEX"
-      }
+   config["lcr-modules"]["_shared"]["unmatched_normal_ids"] = {
+      "capture--grch37": "TCRBOA7-N-WEX"
    }
 
    config["lcr-modules"]["star"]["inputs"]["sample_fastq_1"] = "data/{sample_id}.read1.fastq.gz"
@@ -397,10 +402,8 @@ Alternatively, some of the redundancy can be avoided by using the `Snakemake upd
    import snakemake as smk
 
    smk.utils.update_config(config["lcr-modules"]["_shared"], {
-      "pairing_config": {
-         "capture": {
-            "unmatched_normal_id": "TCRBOA7-N-WEX"
-         }
+      "unmatched_normal_ids": {
+         "capture--grch37": "TCRBOA7-N-WEX"
       }
    })
 

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -1117,6 +1117,7 @@ def generate_runs(
 
     # Generate Sample instances for unmatched normal samples from sample IDs
     Sample = namedtuple("Sample", samples.columns.tolist())
+    sample_genome_builds = samples["genome_build"].unique()
     for seq_type, args_dict in pairing_config.items():
         if (
             "run_unpaired_tumours_with" in args_dict
@@ -1125,7 +1126,11 @@ def generate_runs(
         ):
             unmatched_normals = dict()
             for key, normal_id in unmatched_normal_ids.items():
-                if not key.startswith(f"{seq_type}--"):
+                _, genome_build = key.split("--", 1)
+                if (
+                    not key.startswith(f"{seq_type}--")
+                    or genome_build not in sample_genome_builds
+                ):
                     continue
                 normal_row = samples[
                     (samples.sample_id == normal_id) & (samples.seq_type == seq_type)

--- a/template/cookiecutter.json
+++ b/template/cookiecutter.json
@@ -5,7 +5,7 @@
   "input_file_type": null,
   "output_file_type": null,
   "module_run_per": ["sample", "tumour"],
-  "seq_type.genome": ["unpaired", "paired", "omit"],
-  "seq_type.capture": ["unpaired", "paired", "omit"],
-  "seq_type.mrna": ["unpaired", "paired", "omit"]
+  "seq_type.genome": ["omit", "matched_only", "allow_unmatched", "no_normal"],
+  "seq_type.capture": ["omit", "matched_only", "allow_unmatched", "no_normal"],
+  "seq_type.mrna": ["omit", "matched_only", "allow_unmatched", "no_normal"]
 }

--- a/template/hooks/pre_gen_project.py
+++ b/template/hooks/pre_gen_project.py
@@ -38,7 +38,7 @@ assert re.fullmatch(r"[a-z0-9_]+", output_file_type), (
 # Ensure that a sample-based module isn't run with a paired seq_type
 if module_run_per == "sample":
     for seq_type, mode in seq_types.items():
-        assert mode != "paired", (
+        assert mode not in ["matched_only", "allow_unmatched"], (
             f"`module_run_per` set to 'sample', but `seq_type.{seq_type}` set to "
-            "'paired'. For paired analyses, select 'tumour' for `module_run_per`."
+            f"'{mode}'. For paired analyses, select 'tumour' for `module_run_per`."
         )

--- a/template/{{cookiecutter.module_name}}/1.0/config/default.yaml
+++ b/template/{{cookiecutter.module_name}}/1.0/config/default.yaml
@@ -32,11 +32,15 @@ lcr-modules:
         {%- for seq_type, mode in cookiecutter.items() if seq_type.startswith("seq_type.") %}
             {%- if mode != "omit" %}
             {{ seq_type | replace("seq_type.", "", 1) }}:
-            {%- if mode == "paired" %}
+            {%- if mode == "matched_only" %}
+                run_paired_tumours: True
+                run_unpaired_tumours_with: null
+                run_paired_tumours_as_unpaired: False
+            {%- elif mode == "allow_unmatched" %}
                 run_paired_tumours: True
                 run_unpaired_tumours_with: "unmatched_normal"
                 run_paired_tumours_as_unpaired: False
-            {%- elif mode == "unpaired" %}
+            {%- elif mode == "no_normal" %}
                 run_paired_tumours: False
                 run_unpaired_tumours_with: "no_normal"
                 run_paired_tumours_as_unpaired: True


### PR DESCRIPTION
This PR allows unmatched normal IDs to be associated with both seq_types and genome_builds. This PR is backwards-compatible with the old way of specifying `unmatched_normal_id` in the `pairing_config`. I need to update the docs in this branch before merging it into master. 