### PR TITLE
fixed mem_mb to allow demanding indexing jobs to complete

### DIFF
--- a/demo/Snakefile
+++ b/demo/Snakefile
@@ -16,9 +16,9 @@ subworkflow reference_files:
     workdir:
         "reference/"
     snakefile:
-        "../workflows/reference_files/2.2/reference_files.smk"
+        "../workflows/reference_files/2.3/reference_files.smk"
     configfile:
-        "../workflows/reference_files/2.2/config/default.yaml"
+        "../workflows/reference_files/2.3/config/default.yaml"
 
 
 ##### CONFIGURATION FILES #####

--- a/workflows/reference_files/2.3/reference_files.smk
+++ b/workflows/reference_files/2.3/reference_files.smk
@@ -37,6 +37,8 @@ rule create_bwa_index:
     log: 
         "genomes/{genome_build}/bwa_index/bwa-{bwa_version}/genome.fa.log"
     conda: CONDA_ENVS["bwa"]
+    resources:
+        mem_mb = 20000
     shell:
         "bwa index -p {output.prefix} {input.fasta} > {log} 2>&1"
 
@@ -51,14 +53,16 @@ rule create_star_index:
         "genomes/{genome_build}/star_index/star-{star_version}/gencode-{gencode_release}/overhang-{star_overhang}.log"
     conda: CONDA_ENVS["star"]
     threads: 12
+    resources:
+        mem_mb = 42000
     shell:
         op.as_one_line("""
         mkdir -p {output.index}
             &&
         STAR --runThreadN {threads} --runMode genomeGenerate --genomeDir {output.index}
         --genomeFastaFiles {input.fasta} --sjdbOverhang {wildcards.star_overhang}
-        --sjdbGTFfile {input.gtf} --outTmpDir {output.index}/_STARtmp > {log} 2>&1
-        --outFileNamePrefix {output.index}/
+        --sjdbGTFfile {input.gtf} --outTmpDir {output.index}/_STARtmp
+        --outFileNamePrefix {output.index}/ > {log} 2>&1
         """)
 
 

--- a/workflows/reference_files/2.3/reference_files_header.smk
+++ b/workflows/reference_files/2.3/reference_files_header.smk
@@ -23,9 +23,7 @@ localrules: download_genome_fasta,
             get_genome_fasta_download, 
             index_genome_fasta,
             get_main_chromosomes_download, 
-            create_bwa_index,
-            get_gencode_download, 
-            create_star_index
+            get_gencode_download
 
 
 # Check for genome builds


### PR DESCRIPTION


## Checklist for Updated Module
I have fixed reference_files to run on a cluster by adding mem_mb in a few places. I suggest we consider keeping the version naming the same here because the outputs (when successful) should be identical. 
