### PR TITLE
Do not try to reinstall copynumber package

### DIFF
--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -1,0 +1,48 @@
+lcr-modules:
+    
+    sequenza:
+
+        inputs:
+            # Available wildcards: {seq_type} {genome_build} {sample_id}
+            sample_bam: "__UPDATE__"
+            sample_bai: "__UPDATE__"
+            merge_seqz: "{MODSDIR}/src/bash/merge_seqz.sh"
+            filter_seqz: "{MODSDIR}/src/bash/filter_seqz.sh"
+            run_sequenza: "{MODSDIR}/src/R/run_sequenza.R"
+            cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.0/cnv2igv.py"
+
+        scratch_subdirectories: ["seqz"]
+        
+        options:
+            bam2seqz: "--qlimit 30"
+            seqz_binning: "--window 300"
+            cnv2igv: "--mode sequenza"
+
+        conda_envs:
+            sequenza-utils: "{MODSDIR}/envs/sequenza-utils-3.0.0.yaml"
+            r-sequenza: "{MODSDIR}/envs/r-sequenza-3.0.0.yaml"
+            cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.0/python-3.8.3.yaml"
+            
+        threads:
+            bam2seqz: 3
+            merge_seqz: 1
+            filter_seqz: 1
+            sequenza: 8 
+
+        mem_mb:
+            vcf_sort: 2000
+            bam2seqz: 10000
+            merge_seqz: 10000
+            filter_seqz: 20000
+            sequenza: 20000
+
+        # For now, only supporting matched tumour-normal pairs
+        pairing_config:
+            genome:
+                run_paired_tumours: True
+                run_unpaired_tumours_with: null
+                run_paired_tumours_as_unpaired: False
+            capture:
+                run_paired_tumours: True
+                run_unpaired_tumours_with: null
+                run_paired_tumours_as_unpaired: False

--- a/modules/sequenza/1.4/envs/r-sequenza-3.0.0.yaml
+++ b/modules/sequenza/1.4/envs/r-sequenza-3.0.0.yaml
@@ -1,0 +1,1 @@
+../../../../envs/r-sequenza/r-sequenza-3.0.0.yaml

--- a/modules/sequenza/1.4/envs/sequenza-utils-3.0.0.yaml
+++ b/modules/sequenza/1.4/envs/sequenza-utils-3.0.0.yaml
@@ -1,0 +1,1 @@
+../../../../envs/sequenza-utils/sequenza-utils-3.0.0.yaml

--- a/modules/sequenza/1.4/schemas/base-1.0.yaml
+++ b/modules/sequenza/1.4/schemas/base-1.0.yaml
@@ -1,0 +1,1 @@
+../../../../schemas/base/base-1.0.yaml

--- a/modules/sequenza/1.4/sequenza.smk
+++ b/modules/sequenza/1.4/sequenza.smk
@@ -1,0 +1,238 @@
+#!/usr/bin/env snakemake
+
+
+##### ATTRIBUTION #####
+
+
+# Original Author:  Ryan Morin
+# Module Author:    Ryan Morin
+# Contributors:     Bruno Grande
+
+
+##### SETUP #####
+
+
+# Import package with useful functions for developing analysis modules
+import oncopipe as op
+
+# Setup module and store module-specific configuration in `CFG`
+# `CFG` is a shortcut to `config["lcr-modules"]["sequenza"]`
+CFG = op.setup_module(
+    name = "sequenza",
+    version = "1.4",
+    subdirectories = ["inputs", "seqz", "sequenza", "igv_seg", "outputs"]
+)
+
+# Define rules to be run locally when using a compute cluster
+localrules:
+    _sequenza_input_bam,
+    _sequenza_input_chroms,
+    _sequenza_input_dbsnp_pos,
+    _sequenza_cnv2igv,
+    _sequenza_output_seg,
+    _sequenza_all,
+
+
+##### RULES #####
+
+
+# Symlinks the input files into the module results directory (under '00-inputs/')
+rule _sequenza_input_bam:
+    input:
+        bam = CFG["inputs"]["sample_bam"],
+        bai = CFG["inputs"]["sample_bai"]
+    output:
+        bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam",
+        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bai"
+    run:
+        op.relative_symlink(input.bam, output.bam)
+        op.relative_symlink(input.bai, output.bai)
+
+
+# Pulls in list of chromosomes for the genome builds
+checkpoint _sequenza_input_chroms:
+    input:
+        txt = reference_files("genomes/{genome_build}/genome_fasta/main_chromosomes.txt")
+    output:
+        txt = CFG["dirs"]["inputs"] + "chroms/{genome_build}/main_chromosomes.txt"
+    run:
+        op.relative_symlink(input.txt, output.txt)
+
+
+# Pulls in list of chromosomes for the genome builds
+rule _sequenza_input_dbsnp_pos:
+    input:
+        vcf = reference_files("genomes/{genome_build}/variation/dbsnp.common_all-151.vcf.gz")
+    output:
+        pos = CFG["dirs"]["inputs"] + "dbsnp/{genome_build}/dbsnp.common_all-151.pos"
+    log:
+        stderr = CFG["logs"]["inputs"] + "{genome_build}/sequenza_input_dbsnp_pos.stderr.log"
+    resources:
+        mem_mb = CFG["mem_mb"]["vcf_sort"]
+    shell:
+        op.as_one_line("""
+        gzip -dc {input.vcf}
+            |
+        awk 'BEGIN {{FS="\t"}} $0 !~ /^#/ {{print $1 ":" $2}}' 2>> {log.stderr}
+            |
+        LC_ALL=C sort -S {resources.mem_mb}M > {output.pos} 2>> {log.stderr}
+        """)
+
+
+rule _sequenza_bam2seqz:
+    input:
+        tumour_bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{tumour_id}.bam",
+        normal_bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{normal_id}.bam",
+        gc_wiggle = reference_files("genomes/{genome_build}/annotations/gc_wiggle.window_50.wig.gz"),
+        genome = reference_files("genomes/{genome_build}/genome_fasta/genome.fa")
+    output:
+        seqz = temp(CFG["dirs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/chromosomes/{chrom}.binned.seqz.gz")
+    log:
+        stderr = CFG["logs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_bam2seqz.{chrom}.stderr.log"
+    params:
+        bam2seqz_opts = CFG["options"]["bam2seqz"],
+        seqz_binning_opts = CFG["options"]["seqz_binning"]
+    conda:
+        CFG["conda_envs"]["sequenza-utils"]
+    threads:
+        CFG["threads"]["bam2seqz"]
+    resources:
+        mem_mb = CFG["mem_mb"]["bam2seqz"],
+	bam = 1
+    shell:
+        op.as_one_line("""
+        sequenza-utils bam2seqz {params.bam2seqz_opts} -gc {input.gc_wiggle} --fasta {input.genome} 
+        --normal {input.normal_bam} --tumor {input.tumour_bam} --chromosome {wildcards.chrom} 2>> {log.stderr}
+            | 
+        sequenza-utils seqz_binning {params.seqz_binning_opts} --seqz - 2>> {log.stderr}
+            |
+        gzip > {output} 2>> {log.stderr}
+        """)
+
+
+def _sequenza_request_chrom_seqz_files(wildcards):
+    CFG = config["lcr-modules"]["sequenza"]
+    with open(checkpoints._sequenza_input_chroms.get(**wildcards).output.txt) as f:
+        mains_chroms = f.read().rstrip("\n").split("\n")
+    seqz_files = expand(
+        CFG["dirs"]["seqz"] + "{{seq_type}}--{{genome_build}}/{{tumour_id}}--{{normal_id}}--{{pair_status}}/chromosomes/{chrom}.binned.seqz.gz", 
+        chrom=mains_chroms
+    )
+    return seqz_files
+
+
+rule _sequenza_merge_seqz:
+    input:
+        seqz = _sequenza_request_chrom_seqz_files,
+        merge_seqz = CFG["inputs"]["merge_seqz"],
+        gc = reference_files("genomes/{genome_build}/annotations/gc_wiggle.window_50.wig.gz")
+    output:
+        seqz = CFG["dirs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/merged.binned.unfiltered.seqz.gz"
+    log:
+        stderr = CFG["logs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_merge_seqz.stderr.log"
+    threads: CFG["threads"]["merge_seqz"]
+    resources: 
+        mem_mb = CFG["mem_mb"]["merge_seqz"]
+    shell:
+        op.as_one_line("""
+        bash {input.merge_seqz} {input.seqz} 2>> {log.stderr}
+            | 
+        gzip > {output.seqz} 2>> {log.stderr}
+        """)
+
+
+rule _sequenza_filter_seqz:
+    input:
+        seqz = str(rules._sequenza_merge_seqz.output.seqz),
+        filter_seqz = CFG["inputs"]["filter_seqz"],
+        dbsnp_pos = str(rules._sequenza_input_dbsnp_pos.output.pos)
+    output:
+        seqz = CFG["dirs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/merged.binned.filtered.seqz.gz"
+    log:
+        stderr = CFG["logs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_filter_seqz.stderr.log"
+    threads: CFG["threads"]["filter_seqz"]
+    resources: 
+        mem_mb = CFG["mem_mb"]["filter_seqz"]
+    shell:
+        op.as_one_line("""
+        {input.filter_seqz} {input.seqz} {input.dbsnp_pos} 2>> {log.stderr}
+            |
+        gzip > {output.seqz} 2>> {log.stderr}
+        """)
+
+
+rule _sequenza_run:
+    input:
+        seqz = CFG["dirs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/merged.binned.{filter_status}.seqz.gz",
+        run_sequenza = CFG["inputs"]["run_sequenza"],
+        assembly = reference_files("genomes/{genome_build}/version.txt"),
+        chroms = reference_files("genomes/{genome_build}/genome_fasta/main_chromosomes.txt"),
+        x_chrom = reference_files("genomes/{genome_build}/genome_fasta/chromosome_x.txt")
+    output:
+        segments = CFG["dirs"]["sequenza"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{filter_status}/sequenza_segments.txt"
+    log:
+        stdout = CFG["logs"]["sequenza"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_run.{filter_status}.stdout.log",
+        stderr = CFG["logs"]["sequenza"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_run.{filter_status}.stderr.log"
+    conda:
+        CFG["conda_envs"]["r-sequenza"]
+    threads: CFG["threads"]["sequenza"]
+    resources: 
+        mem_mb = CFG["mem_mb"]["sequenza"]
+    shell:
+        op.as_one_line("""
+        Rscript {input.run_sequenza} {input.seqz} {input.assembly} {input.chroms} {input.x_chrom} 
+        $(dirname {output.segments}) {threads} > {log.stdout} 2> {log.stderr}
+        """)
+
+
+rule _sequenza_cnv2igv:
+    input:
+        segments = str(rules._sequenza_run.output.segments),
+        cnv2igv =  CFG["inputs"]["cnv2igv"]
+    output:
+        igv = CFG["dirs"]["igv_seg"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{filter_status}/sequenza_segments.igv.seg"
+    log:
+        stderr = CFG["logs"]["igv_seg"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/cnv2igv.{filter_status}.stderr.log"
+    params:
+        opts = CFG["options"]["cnv2igv"]
+    conda:
+        CFG["conda_envs"]["cnv2igv"]
+    shell:
+        op.as_one_line("""
+        python {input.cnv2igv} {params.opts} --sample {wildcards.tumour_id} 
+        {input.segments} > {output} 2> {log.stderr}
+        """)
+
+
+# Symlinks the final output files into the module results directory (under '99-outputs/')
+rule _sequenza_output_seg:
+    input:
+        seg = str(rules._sequenza_cnv2igv.output.igv)
+    output:
+        seg = CFG["dirs"]["outputs"] + "{filter_status}_seg/{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}.igv.seg"
+    run:
+        op.relative_symlink(input.seg, output.seg)
+
+
+# Generates the target sentinels for each run, which generate the symlinks
+rule _sequenza_all:
+    input:
+        expand(
+            [
+                str(rules._sequenza_output_seg.output.seg).replace("{filter_status}", "filtered"),
+                str(rules._sequenza_output_seg.output.seg).replace("{filter_status}", "unfiltered"),
+            ],
+            zip,  # Run expand() with zip(), not product()
+            seq_type=CFG["runs"]["tumour_seq_type"],
+            genome_build=CFG["runs"]["tumour_genome_build"],
+            tumour_id=CFG["runs"]["tumour_sample_id"],
+            normal_id=CFG["runs"]["normal_sample_id"],
+            pair_status=CFG["runs"]["pair_status"])
+
+
+##### CLEANUP #####
+
+
+# Perform some clean-up tasks, including storing the module-specific
+# configuration on disk and deleting the `CFG` variable
+op.cleanup_module(CFG)

--- a/modules/sequenza/1.4/src/R/run_sequenza.R
+++ b/modules/sequenza/1.4/src/R/run_sequenza.R
@@ -1,0 +1,92 @@
+#!/usr/bin/env Rscript
+
+
+# Load Packages -----------------------------------------------------------
+
+# Install default copynumber package if it is not already installed
+  if ("copynumber" %in% installed.packages()==FALSE){
+    BiocManager::install("copynumber")
+  }
+# Install copynumber package supporting hg38 genome build
+  if (is.null(packageDescription("copynumber")$GithubUsername)) {
+    remotes::install_github("ShixiangWang/copynumber", dependencies = FALSE)
+  }
+
+library(sequenza)
+
+
+# Parse Arguments ---------------------------------------------------------
+
+args      <- commandArgs(trailingOnly=TRUE)
+seqz_path <- args[[1]]
+assembly  <- args[[2]]
+chroms    <- args[[3]]
+x_chrom   <- args[[4]]
+odir_path <- args[[5]]
+num_cores <- args[[6]]
+
+
+# Prepare variables -------------------------------------------------------
+
+assembly <- readLines(assembly)
+
+to_ucsc <- list(
+  hg19 = "hg19",
+  hg38 = "hg38",
+  grch37 = "hg19",
+  grch38 = "hg38"
+)
+
+stopifnot(assembly %in% names(to_ucsc))
+assembly_ucsc <- to_ucsc[[assembly]]
+assembly_ucsc <- unname(assembly_ucsc)
+
+chroms <- readLines(chroms)
+
+x_chrom <- readLines(x_chrom)
+
+if (is.null(num_cores)) num_cores <- 1
+num_cores <- as.integer(num_cores)
+
+
+# Load Data ---------------------------------------------------------------
+
+seqz <- sequenza.extract(
+  seqz_path,
+  chromosome.list = chroms,
+  assembly = assembly_ucsc
+)
+
+
+# Fit Cellularity and Ploidy ----------------------------------------------
+
+num_positions <- sum(seqz$depths$norm$normal[[x_chrom]]$N, na.rm = TRUE)
+if (num_positions < 1e6) {
+  warn <- paste0("There are fewer than 1 million positions with depth data on the ",
+                 "X chromosome. This usually means the input data was based on ",
+                 "exomes, which will fail the sex inferrence step.")
+  warning(warn)
+}
+
+chrx_ratio <- median(seqz$depths$norm$normal[[x_chrom]]$mean, na.rm = TRUE)
+is_female <- chrx_ratio >= 0.75
+sex <- ifelse(is_female, "female", "male")
+message(paste0("Inferring this patient as ", sex, "."))
+
+fit <- sequenza.fit(
+  seqz,
+  female = is_female,
+  mc.cores = num_cores
+)
+
+
+# Output Results ----------------------------------------------------------
+
+res <- sequenza.results(
+  seqz,
+  fit,
+  sample.id = "sequenza",
+  out.dir = odir_path,
+  female = is_female,
+  chromosome.list = chroms
+)

--- a/modules/sequenza/1.4/src/bash/filter_seqz.sh
+++ b/modules/sequenza/1.4/src/bash/filter_seqz.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+# Usage: 
+#   merge_seqz.sh all.seqz.gz dbsnp.pos [rare_vars.pos] | gzip > all.filt.seqz.gz
+
+SEQZ_FILE="$1"
+DBSNP_POS_FILE="$2"
+RARE_VARIANTS_TMP=$(mktemp /tmp/merge_seqz.sh.XXXXXX)
+RARE_VARIANTS="${3:-${RARE_VARIANTS_TMP}}"
+
+BUFFER_SIZE="${BUFFER_SIZE:-20G}"
+export LC_ALL=C  # Set sort locale to be consistent
+# Check the DPSNP_POS_FILE is sorted
+sort -c $2 || { echo "Provided DBSNP_POS file is not sorted. Check that your \'LC_ALL\' envionmental variable is set to \'$LC_ALL\'" && exit 1; }
+
+set -euf -o pipefail
+
+zcat "${SEQZ_FILE}" \
+	| egrep -v "^chromosome" \
+	| awk 'BEGIN {FS="\t"} $9 == "het" {print $1 ":" $2}' \
+	| sort -S "${BUFFER_SIZE}" --parallel 10 \
+	| comm - "${DBSNP_POS_FILE}" -2 -3 \
+	| tr ":" "\t" \
+	> "${RARE_VARIANTS}"
+
+zgrep -v -F -f "${RARE_VARIANTS}" "${SEQZ_FILE}"
+
+rm -f "${RARE_VARIANTS_TMP}"

--- a/modules/sequenza/1.4/src/bash/merge_segs.sh
+++ b/modules/sequenza/1.4/src/bash/merge_segs.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+#set -euf -o pipefail
+#LC_ALL=C
+
+# Output header from one file
+grep "start" $1
+
+# Contatenate the non-header portions of all files
+grep -v -h "start" $@

--- a/modules/sequenza/1.4/src/bash/merge_sequenza_segs.sh
+++ b/modules/sequenza/1.4/src/bash/merge_sequenza_segs.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+grep "chromosome" $1
+
+grep -vh "chromosome" $@

--- a/modules/sequenza/1.4/src/bash/merge_seqz.sh
+++ b/modules/sequenza/1.4/src/bash/merge_seqz.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+# Usage: 
+#   merge_seqz.sh chr1.seqz.gz chr2.seqz.gz [...] | gzip > all.seqz.gz
+
+set -euf
+
+gzip -dc "$1" | head -1
+
+zcat "$@" | egrep -v "^chromosome" 


### PR DESCRIPTION
I did following changes to the sequenza module:
1. For the run sequenza R script, I have added if statement so when copynumber package supporting hg38 is installed, it is not attempted to be installed again. Otherwise, remotes is checking the package updates every time every sample is run.
2. Added resources: bam=1 to the bam2seqz rule of snakemake file. This will help to manage the concurrent number of jobs that are running at the same time.
3. Created a hard version of src folder in this version instead of symlinking it to the version 1.0