### PR TITLE
Make relative symlinks truly relative and add absolute_symlink function

### DIFF
--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -191,7 +191,7 @@ def prepare_symlink(src, dest):
     # Or you are symlinking a directory to a specific location
     else:
         dest_dir, dest_file = os.path.split(dest)
-    os.makedirs(dest_dir, exist_ok=True)
+    os.makedirs(os.path.abspath(dest_dir), exist_ok=True)
     dest = os.path.join(dest_dir, dest_file)
     
     return src, dest

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -164,7 +164,7 @@ def set_value(value, *keys):
 # UTILITIES
 
 
-def relative_symlink(src, dest, overwrite=True):
+def relative_symlink(src, dest, overwrite=True, force_relative=False):
     """Creates a relative symlink from any working directory.
 
     Parameters
@@ -177,6 +177,8 @@ def relative_symlink(src, dest, overwrite=True):
         to the source file name (unless directory).
     overwrite : boolean
         Whether to overwrite the destination file if it exists.
+    force_relative: boolean
+        Whether to force relative symlinks even if the source file path is absolute. 
     """
 
     # Coerce length-1 NamedList instances to strings
@@ -221,8 +223,7 @@ def relative_symlink(src, dest, overwrite=True):
     )
 
     # Make `src` relative to destination parent directory
-    if not os.path.isabs(src):
-        dest_dir = os.path.realpath(dest_dir)
+    if not os.path.isabs(src) or force_relative:
         src = os.path.relpath(src, dest_dir)
     os.symlink(src, dest)
 

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -202,7 +202,14 @@ def compare_links(src, dest, overwrite):
         # If the destination link exists and has the same src, exit
         if src == os.readlink(dest) or overwrite:
             os.remove(dest)
-    assert not os.path.exists(dest), (
+    # Raise error if the file exists and isn't a symbolic link
+    assert not (os.path.exists(dest) and not os.path.islink(dest)), (
+        "Destination file already exists but isn't a symbolic link: \n"
+        f"    Current: {dest} \n"
+        f"    Attempted: {dest} -> {src}"
+    )
+    # Raise error if the file exists and is a symbolic link
+    assert not (os.path.exists(dest) and os.path.islink(dest)), (
         "Symbolic link already exists but points elsewhere: \n"
         f"    Current: {dest} -> {os.readlink(dest)} \n"
         f"    Attempted: {dest} -> {src}"

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -163,24 +163,7 @@ def set_value(value, *keys):
 
 # UTILITIES
 
-
-def relative_symlink(src, dest, overwrite=True, force_relative=False):
-    """Creates a relative symlink from any working directory.
-
-    Parameters
-    ----------
-    src : str
-        The source file or directory path.
-    dest : str
-        The destination file path. This can also be a destination
-        directory, and the destination symlink name will be identical
-        to the source file name (unless directory).
-    overwrite : boolean
-        Whether to overwrite the destination file if it exists.
-    force_relative: boolean
-        Whether to force relative symlinks even if the source file path is absolute. 
-    """
-
+def prepare_symlinks(src, dest):
     # Coerce length-1 NamedList instances to strings
     def coerce_namedlist_to_string(obj):
         if isinstance(obj, smk.io.Namedlist) and len(obj) == 1:
@@ -222,9 +205,52 @@ def relative_symlink(src, dest, overwrite=True, force_relative=False):
         f"    Attempted: {dest} -> {os.path.realpath(src)}"
     )
 
-    # Make `src` relative to destination parent directory
-    if not os.path.isabs(src) or force_relative:
-        src = os.path.relpath(src, dest_dir)
+    return [src, dest]
+
+def absolute_symlink(src, dest, overwrite=True): 
+    """Creates an absolute symlink from any working directory.
+
+    Parameters
+    ----------
+    src : str
+        The source file or directory path.
+    dest : str
+        The destination file path. This can also be a destination
+        directory, and the destination symlink name will be identical
+        to the source file name (unless directory).
+    overwrite : boolean
+        Whether to overwrite the destination file if it exists.
+    """
+    # Prepare source and destination file paths 
+    src, dest = prepare_symlinks(src, dest)
+    # Retrieve the absolute file path for the source file
+    src = os.path.abspath(src)
+    # Symlink the source file to the destination
+    os.symlink(src, dest)
+
+def relative_symlink(src, dest, overwrite=True):
+    """Creates a relative symlink from any working directory.
+
+    Parameters
+    ----------
+    src : str
+        The source file or directory path.
+    dest : str
+        The destination file path. This can also be a destination
+        directory, and the destination symlink name will be identical
+        to the source file name (unless directory).
+    overwrite : boolean
+        Whether to overwrite the destination file if it exists.
+    """
+    # Prepare source and destination file paths 
+    src, dest = prepare_symlinks(src, dest)
+    # Retrieve the relative file path for the source file
+    print(dest)
+    dest_dir = os.path.split(dest)[0]
+    print(dest_dir)
+    print(src)
+    src = os.path.relpath(src, dest_dir)
+    # Symlink the source file to the destination
     os.symlink(src, dest)
 
 

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -200,9 +200,7 @@ def compare_links(src, dest, overwrite):
     # Check if the destination file exists and is a symlink
     if os.path.lexists(dest) and os.path.islink(dest):
         # If the destination link exists and has the same src, exit
-        if src == os.readlink(dest):
-            exit(0) 
-        elif overwrite:
+        if src == os.readlink(dest) or overwrite:
             os.remove(dest)
     assert not os.path.exists(dest), (
         "Symbolic link already exists but points elsewhere: \n"


### PR DESCRIPTION
The purpose of this change is to allow `op.relative_symlink()` to make symlinks truly relative. Previously [this line](https://github.com/LCR-BCCRC/lcr-modules/blob/cb2b9cc61ad1e3b704aa446caff4cc87b05b646d/oncopipe/oncopipe/__init__.py#L225) used `os.path.realpath()` to determine the destination directory. If the destination directory had a symlink anywhere in its path, the relative symlink would track back to the last common directory, usually outside of the project directory and definitely outside of the module results directory. Removing that line allows the symlinks to be made truly relative. No changes to the cookiecutter module were required because the condition `if not os.path.isabs(src)` was already true for the non-absolute paths used by lcr-modules. I still added a `force_relative` condition so that symlinks can be made relative if the source path is absolute.

I've tested this on a couple of lcr-modules by deleting and initiating regeneration of the symlinks in `99-outputs` and I can confirm that it now generates truly relative paths without the need for changes to any of the module Snakemake code.