### PR TITLE
Crossmap addition to vcf2maf module

### DIFF
--- a/modules/vcf2maf/1.1/config/default.yaml
+++ b/modules/vcf2maf/1.1/config/default.yaml
@@ -7,6 +7,7 @@ lcr-modules:
             # Available wildcards: {out_dir}, {seq_type}, {genome_build}, {tumour_id}, {normal_id}, {pair_status}, {vcf_name}, {base_name}
             vep_cache: "__UPDATE__" #example "ref/ensembl_vep_cache/"
             sample_vcf_gz: "__UPDATE__" #full path to your compressed vcfs from favourite variant caller (with wildcards. You must encapsulate everything unique to the variant caller naming scheme in {base_name})
+            convert_coord: "{SCRIPTSDIR}/crossmap/1.0/convert_maf_coords.sh"
         vcf_base_name: "__UPDATE__" #put the consistent portion of the file name here. For Strelka, this is "combined.passed"
         options:
             vcf2maf: "--filter-vcf 0 --vcf-tumor-id TUMOR --vcf-normal-id NORMAL --cache-version 86"
@@ -14,9 +15,16 @@ lcr-modules:
             #--species        Ensembl-friendly name of species (e.g. mus_musculus for mouse) [homo_sapiens]
             #--cache-version  Version of offline cache to use with VEP (e.g. 75, 84, 91) [Default: Installed version]
             species: "homo_sapiens"
+        switches:
+            chains:
+                # specify path to the chain files used for crossmap conversion
+                grch37: "__UPDATE__"
+                grch37d5: "__UPDATE__"
+                hg38: "__UPDATE__"
 
         conda_envs:
             vcf2maf: "{MODSDIR}/envs/vcf2maf-1.6.18.yaml"
+            crossmap: "{SCRIPTSDIR}/crossmap/1.0/convert_maf_coords.yaml"
             
         threads:
             vcf2maf: 12

--- a/modules/vcf2maf/1.1/config/default.yaml
+++ b/modules/vcf2maf/1.1/config/default.yaml
@@ -15,12 +15,6 @@ lcr-modules:
             #--species        Ensembl-friendly name of species (e.g. mus_musculus for mouse) [homo_sapiens]
             #--cache-version  Version of offline cache to use with VEP (e.g. 75, 84, 91) [Default: Installed version]
             species: "homo_sapiens"
-        switches:
-            chains:
-                # specify path to the chain files used for crossmap conversion
-                grch37: "__UPDATE__"
-                grch37d5: "__UPDATE__"
-                hg38: "__UPDATE__"
 
         conda_envs:
             vcf2maf: "{MODSDIR}/envs/vcf2maf-1.6.18.yaml"

--- a/modules/vcf2maf/1.1/vcf2maf.smk
+++ b/modules/vcf2maf/1.1/vcf2maf.smk
@@ -122,7 +122,7 @@ rule _vcf2maf_crossmap:
 
 rule _vcf2maf_output_maf:
     input:
-        maf = rules._vcf2maf_run.output.maf,
+        maf = str(rules._vcf2maf_run.output.maf),
         maf_converted = rules._vcf2maf_crossmap.output.maf
     output:
         maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf",

--- a/modules/vcf2maf/1.1/vcf2maf.smk
+++ b/modules/vcf2maf/1.1/vcf2maf.smk
@@ -20,7 +20,7 @@ import oncopipe as op
 CFG = op.setup_module(
     name = "vcf2maf",
     version = "1.1",
-    subdirectories = ["inputs","decompressed","vcf2maf","outputs"]
+    subdirectories = ["inputs","decompressed","vcf2maf","crossmap","outputs"]
 )
 
 # Define rules to be run locally when using a compute cluster
@@ -28,6 +28,7 @@ localrules:
     _vcf2maf_input_vcf,
     _vcf2maf_decompress_vcf,
     _vcf2maf_output_maf,
+    _vcf2maf_crossmap,
     _vcf2maf_all
 
 VERSION_MAP = {
@@ -91,18 +92,50 @@ rule _vcf2maf_run:
         > {log.stdout} 2> {log.stderr}
         """)
 
+rule _vcf2maf_crossmap:
+    input:
+        maf = rules._vcf2maf_run.output.maf,
+        convert_coord = CFG["inputs"]["convert_coord"]
+    output:
+        maf =  CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted.maf"
+    log:
+        stdout = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}_crossmap.stdout.log",
+        stderr = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}_crossmap.stderr.log"
+    params:
+        chain = op.switch_on_wildcard("genome_build", CFG["switches"]["chains"])
+    conda:
+        CFG["conda_envs"]["crossmap"]
+    threads:
+        CFG["threads"]["vcf2maf"]
+    resources:
+        mem_mb = CFG["mem_mb"]["vcf2maf"]
+    shell:
+        op.as_one_line("""
+        {input.convert_coord}
+        {input.maf}
+        {params.chain}
+        {output.maf}
+        crossmap
+        > {log.stdout} 2> {log.stderr}
+        """)
+
+
 rule _vcf2maf_output_maf:
     input:
-        maf = str(rules._vcf2maf_run.output.maf)
+        maf = rules._vcf2maf_run.output.maf,
+        maf_converted = rules._vcf2maf_crossmap.output.maf
     output:
-        maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf"
+        maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf",
+        maf_converted = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.converted.maf"
     run:
         op.relative_symlink(input.maf, output.maf)
+        op.relative_symlink(input.maf_converted, output.maf_converted)
 
 # Generates the target sentinels for each run, which generate the symlinks
 rule _vcf2maf_all:
     input:
-        expand(str(rules._vcf2maf_output_maf.output.maf), zip,
+        expand([str(rules._vcf2maf_output_maf.output.maf),
+              str(rules._vcf2maf_output_maf.output.maf_converted)], zip,
             seq_type = CFG["runs"]["tumour_seq_type"],
             genome_build = CFG["runs"]["tumour_genome_build"],
             tumour_id = CFG["runs"]["tumour_sample_id"],

--- a/modules/vcf2maf/CHANGELOG.md
+++ b/modules/vcf2maf/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the `vcf2maf` module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2] - 2020-11-04
+
+This release was authored by Kostia Dreval
+
+- 3rd level analyses of variants often utilize tools that are restricted to either hg19 or hg38 genome build. Therefore, this release of vcf2maf module includes automatic conversion between genome builds using crossmap tool. This implies that maf files in both original and converted genome builds are generated, and conveniently avaliable from the same output folder.
+
+
 ## [1.0] - 2020-06-05
 
 This release was authored by Helena Winata.

--- a/workflows/reference_files/2.4/reference_files.smk
+++ b/workflows/reference_files/2.4/reference_files.smk
@@ -83,6 +83,16 @@ rule create_star_index:
         """)
 
 
+rule get_liftover_chains:
+    input:
+        chains = rules.download_liftover_chains.output.chains
+    output:
+        chains = "genomes/{genome_build}/chains/{chain_version}.over.chain"
+    shell:
+        "ln -srf {input.chains} {output.chains}"
+
+
+
 ##### METADATA #####
 
 

--- a/workflows/reference_files/2.4/reference_files_header.smk
+++ b/workflows/reference_files/2.4/reference_files_header.smk
@@ -27,7 +27,8 @@ localrules: download_genome_fasta,
             get_gencode_download, 
             create_star_index, 
             get_gencode_download,
-            download_af_only_gnomad_vcf
+            download_af_only_gnomad_vcf,
+            download_liftover_chains
 
 
 # Check for genome builds
@@ -298,6 +299,19 @@ rule download_mutect2_small_exac:
         else
             gsutil cp {params.file} {output.vcf} 2> {log}; 
         fi
+        """)
+
+rule download_liftover_chains:
+    output:
+        chains = "downloads/chains/{genome_build}/{chain_version}.over.chain"
+    wildcard_constraints:
+        chain_version = "hg19ToHg38|hg38ToHg19"
+    params:
+        build = lambda w: "hg38" if "38" in str({w.genome_build}) else "hg19"
+    shell:
+        op.as_one_line("""
+        wget -qO- http://hgdownload.cse.ucsc.edu/goldenpath/{params.build}/liftOver/{wildcards.chain_version}.over.chain.gz |
+        gzip -dc > {output.chains}
         """)
 
 


### PR DESCRIPTION
I have updated the vcf2maf module to include conversion of maf files between genome builds. I made sure it is working on 2 test maf files. Once approved, I will move this to v1.2 and incorporate into demo workflow. Please do not merge with master if approved.