### PR TITLE
Fix and improve crossmap in vcf2maf module

### DIFF
--- a/modules/vcf2maf/1.1/vcf2maf.smk
+++ b/modules/vcf2maf/1.1/vcf2maf.smk
@@ -117,7 +117,7 @@ rule _vcf2maf_crossmap:
         mem_mb = CFG["mem_mb"]["vcf2maf"]
     params:
         out_name = CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted_",
-        chain = lambda w: "hg38ToHg19" if "38" in {w.genome_build} else "hg19ToHg38",
+        chain = lambda w: "hg38ToHg19" if "38" in str({w.genome_build}) else "hg19ToHg38",
         file = ".maf"
     shell:
         op.as_one_line("""
@@ -138,7 +138,7 @@ rule _vcf2maf_output_maf:
     output:
         maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf"
     params:
-        chain = lambda w: "hg38ToHg19" if "38" in {w.genome_build} else "hg19ToHg38"
+        chain = lambda w: "hg38ToHg19" if "38" in str({w.genome_build}) else "hg19ToHg38"
     run:
         op.relative_symlink(input.maf, output.maf)
         op.relative_symlink((input.maf_converted+str("_")+str(params.chain)+str(".maf")), (output.maf[:-4]+str(".converted_")+str(params.chain)+str(".maf")))

--- a/modules/vcf2maf/1.1/vcf2maf.smk
+++ b/modules/vcf2maf/1.1/vcf2maf.smk
@@ -105,7 +105,7 @@ rule _vcf2maf_crossmap:
         convert_coord = CFG["inputs"]["convert_coord"],
         chains = get_chain
     output:
-        maf =  CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted"
+        dispatched =  CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted"
     log:
         stdout = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.crossmap.stdout.log",
         stderr = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.crossmap.stderr.log"
@@ -127,14 +127,14 @@ rule _vcf2maf_crossmap:
         {params.out_name}{params.chain}{params.file}
         crossmap
         > {log.stdout} 2> {log.stderr}
-        && touch {output.maf}
+        && touch {output.dispatched}
         """)
 
 
 rule _vcf2maf_output_maf:
     input:
         maf = str(rules._vcf2maf_run.output.maf),
-        maf_converted = str(rules._vcf2maf_crossmap.output.maf)
+        maf_converted = str(rules._vcf2maf_crossmap.output.dispatched)
     output:
         maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf"
     params:

--- a/modules/vcf2maf/1.1/vcf2maf.smk
+++ b/modules/vcf2maf/1.1/vcf2maf.smk
@@ -95,9 +95,9 @@ rule _vcf2maf_run:
 
 def get_chain(wildcards):
     if "38" in str({wildcards.genome_build}):
-        return reference_files("genomes/{genome_build}/chains/hg38ToHg19.over.chain")
+        return reference_files("genomes/{genome_build}/chains/grch38/hg38ToHg19.over.chain")
     else:
-        return reference_files("genomes/{genome_build}/chains/hg19ToHg38.over.chain")
+        return reference_files("genomes/{genome_build}/chains/grch37/hg19ToHg38.over.chain")
 
 rule _vcf2maf_crossmap:
     input:
@@ -105,43 +105,48 @@ rule _vcf2maf_crossmap:
         convert_coord = CFG["inputs"]["convert_coord"],
         chains = get_chain
     output:
-        maf =  CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted.maf"
+        maf =  CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted"
     log:
-        stdout = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}_crossmap.stdout.log",
-        stderr = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}_crossmap.stderr.log"
+        stdout = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.crossmap.stdout.log",
+        stderr = CFG["logs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.crossmap.stderr.log"
     conda:
         CFG["conda_envs"]["crossmap"]
     threads:
         CFG["threads"]["vcf2maf"]
     resources:
         mem_mb = CFG["mem_mb"]["vcf2maf"]
+    params:
+        out_name = CFG["dirs"]["crossmap"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.converted_",
+        chain = lambda w: "hg38ToHg19" if "38" in {w.genome_build} else "hg19ToHg38",
+        file = ".maf"
     shell:
         op.as_one_line("""
         {input.convert_coord}
         {input.maf}
         {input.chains}
-        {output.maf}
+        {params.out_name}{params.chain}{params.file}
         crossmap
         > {log.stdout} 2> {log.stderr}
+        && touch {output.maf}
         """)
 
 
 rule _vcf2maf_output_maf:
     input:
         maf = str(rules._vcf2maf_run.output.maf),
-        maf_converted = rules._vcf2maf_crossmap.output.maf
+        maf_converted = str(rules._vcf2maf_crossmap.output.maf)
     output:
-        maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf",
-        maf_converted = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.converted.maf"
+        maf = CFG["dirs"]["outputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}_{base_name}.maf"
+    params:
+        chain = lambda w: "hg38ToHg19" if "38" in {w.genome_build} else "hg19ToHg38"
     run:
         op.relative_symlink(input.maf, output.maf)
-        op.relative_symlink(input.maf_converted, output.maf_converted)
+        op.relative_symlink((input.maf_converted+str("_")+str(params.chain)+str(".maf")), (output.maf[:-4]+str(".converted_")+str(params.chain)+str(".maf")))
 
 # Generates the target sentinels for each run, which generate the symlinks
 rule _vcf2maf_all:
     input:
-        expand([str(rules._vcf2maf_output_maf.output.maf),
-              str(rules._vcf2maf_output_maf.output.maf_converted)], zip,
+        expand(str(rules._vcf2maf_output_maf.output.maf), zip,
             seq_type = CFG["runs"]["tumour_seq_type"],
             genome_build = CFG["runs"]["tumour_genome_build"],
             tumour_id = CFG["runs"]["tumour_sample_id"],

--- a/workflows/reference_files/2.4/reference_files.smk
+++ b/workflows/reference_files/2.4/reference_files.smk
@@ -87,7 +87,7 @@ rule get_liftover_chains:
     input:
         chains = rules.download_liftover_chains.output.chains
     output:
-        chains = "genomes/{genome_build}/chains/{chain_version}.over.chain"
+        chains = "genomes/{genome_build}/chains/{version}/{chain_version}.over.chain"
     shell:
         "ln -srf {input.chains} {output.chains}"
 

--- a/workflows/reference_files/2.4/reference_files_header.smk
+++ b/workflows/reference_files/2.4/reference_files_header.smk
@@ -303,10 +303,11 @@ rule download_mutect2_small_exac:
 
 rule download_liftover_chains:
     output:
-        chains = "downloads/chains/{genome_build}/{chain_version}.over.chain"
+        chains = "downloads/chains/{genome_build}/{chain_version}.{version}.over.chain"
     wildcard_constraints:
         chain_version = "hg19ToHg38|hg38ToHg19"
     params:
+        provider = lambda w: {"grch37": "ensembl", "grch38": "ucsc"}[w.version],
         build = lambda w: "hg38" if "38" in str({w.genome_build}) else "hg19"
     shell:
         op.as_one_line("""


### PR DESCRIPTION
With addition of crossmap to `vcf2maf` module, my latest commit introduced a bug to the `reference_files` workflow in the rule that downloaded the liftOver chains from UCSC. This caused issue preventing snakemake to run. This PR fixes the bug by including required wildcards `version` and `params.provider` into the rules I added. 
In addition, this PR improves naming of output symlinks from `vcf2maf` module by specifying in file name the chain used for conversion of genomic coordinates. 
This implementation has been tested and run on all current strelka outputs. 