### PR TITLE
Salmon bugfix

### DIFF
--- a/modules/salmon/1.1/salmon.smk
+++ b/modules/salmon/1.1/salmon.smk
@@ -133,9 +133,10 @@ rule build_counts_matrix:
 # Generates the target sentinels for each run, which generate the symlinks
 rule _salmon_all:
     input:
-        expand(rules.build_counts_matrix.output.counts_matrix,
-            zip,  # Run expand() with zip(), not product()
-            seq_type=CFG["samples"]["seq_type"])
+        expand(
+            rules.build_counts_matrix.output.counts_matrix,
+            seq_type=CFG["samples"]["seq_type"].unique().tolist()
+        )
 
 
 ##### CLEANUP #####

--- a/modules/salmon/1.1/salmon.smk
+++ b/modules/salmon/1.1/salmon.smk
@@ -89,6 +89,11 @@ rule _salmon_output:
 
 
 rule export_sample_table:
+    input: 
+        quant = expand(rules._salmon_output.output.quant,
+            zip,
+            seq_type=CFG["samples"]["seq_type"],
+            sample_id=CFG["samples"]["sample_id"])
     output:
         sample_table = CFG["dirs"]["outputs"] + "quant_to_" + CFG["transcriptome"]["quant_to"] + "_matrix/{seq_type}/sample_table.tsv"
     run:

--- a/modules/salmon/1.1/salmon_grouped.smk
+++ b/modules/salmon/1.1/salmon_grouped.smk
@@ -142,9 +142,10 @@ rule build_counts_matrix:
 # Generates the target sentinels for each run, which generate the symlinks
 rule _salmon_all:
     input:
-        expand(rules.build_counts_matrix.output.counts_matrix,
-            zip,  # Run expand() with zip(), not product()
-            seq_type=CFG["samples"]["seq_type"])
+        expand(
+            rules.build_counts_matrix.output.counts_matrix,
+            seq_type=CFG["samples"]["seq_type"].unique().tolist()
+        )
 
 
 ##### CLEANUP #####

--- a/modules/salmon/1.1/salmon_grouped.smk
+++ b/modules/salmon/1.1/salmon_grouped.smk
@@ -93,6 +93,11 @@ rule _salmon_output:
 
 
 rule export_sample_table:
+    input:
+        quant = expand(rules._salmon_output.output.quant,
+            zip,
+            seq_type=CFG["samples"]["seq_type"],
+            sample_id=CFG["samples"]["sample_id"])
     output:
         sample_table = CFG["dirs"]["outputs"] + "quant_to_" + CFG["transcriptome"]["quant_to"] + "_matrix/{seq_type}/sample_table.tsv"
     run:


### PR DESCRIPTION
This PR fixes two small bugs I identified when running Salmon on my LLMPP project. First, the `_salmon_all` rule was requesting the identical matrix for each sample in the table, so I've changed the all rule so that it only requests one matrix per seq_type. Second, the rule `export_sample_table` didn't have any input, so it wasn't updating the output sample table as I added new samples to my matrix. I've included all `quant.sf` files as placeholder input to make sure this gets regenerated every time new samples are added. 