### PR TITLE
fixed manta and strelka to work with cram files

### DIFF
--- a/modules/manta/2.3/manta.smk
+++ b/modules/manta/2.3/manta.smk
@@ -44,10 +44,12 @@ rule _manta_input_bam:
         sample_bai = CFG["inputs"]["sample_bai"]
     output:
         sample_bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam",
-        sample_bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai"
+        sample_bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai",
+        sample_crai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.crai"
     run:
         op.relative_symlink(input.sample_bam, output.sample_bam)
         op.relative_symlink(input.sample_bai, output.sample_bai)
+        op.relative_symlink(input.sample_bai, output.sample_crai)
 
 
 # bgzip-compress and tabix-index the BED file to meet Manta requirement

--- a/modules/manta/CHANGELOG.md
+++ b/modules/manta/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to the `manta` module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.31] - 2020-12-17
+
+This minor version increase enables processing of cram files. The input is expected to be named ".bam" and ".bai" (or symlinks with that naming pointing to the cram and crai). 
+
 ## [2.2] - 2020-07-16
 
 This release was authored by Bruno Grande.

--- a/modules/strelka/1.1/strelka.smk
+++ b/modules/strelka/1.1/strelka.smk
@@ -47,10 +47,12 @@ rule _strelka_input_bam:
         bai = CFG["inputs"]["sample_bai"]
     output:
         bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam",
-        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai"
+        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai",
+        crai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.crai"
     run:
         op.relative_symlink(input.bam, output.bam)
         op.relative_symlink(input.bai, output.bai)
+        op.relative_symlink(input.bai, output.crai)
 
 
 rule _strelka_dummy_vcf:

--- a/modules/strelka/CHANGELOG.md
+++ b/modules/strelka/CHANGELOG.md
@@ -33,3 +33,7 @@ Update by Ryan Morin
  - Step to combine indel and snv into one "combined" output file
  - Only the filtered vcfs are merged and ultimately symlinked (along with their tbi files)
  - Output files are all named based on sample instead of having the same name and being separated by subdirectories. Avoids future issues with files being relocated. 
+
+## [1.11] - 2020-12-17
+
+- slight modification to allow cram files to be used as input (same functionality as Manta)


### PR DESCRIPTION
very minor changes. Just creates a second symlink to the bai file with a name expected by strelka/manta. 