### PR TITLE
Module/sage/1.0

### DIFF
--- a/envs/hmftools/hmftools-sage-2.6.yaml
+++ b/envs/hmftools/hmftools-sage-2.6.yaml
@@ -30,7 +30,7 @@ dependencies:
   - gxx_impl_linux-64=7.3.0
   - gxx_linux-64=7.3.0
   - harfbuzz=2.4.0
-  - hmftools-sage=2.2
+  - hmftools-sage=2.6
   - icu=58.2
   - jpeg=9d
   - kernel-headers_linux-64=2.6.32

--- a/modules/sage/1.0/config/default.yaml
+++ b/modules/sage/1.0/config/default.yaml
@@ -15,7 +15,7 @@ lcr-modules:
 
 
         conda_envs:
-            sage: "{MODSDIR}/envs/hmftools-sage-2.2.yaml"
+            sage: "{MODSDIR}/envs/hmftools-sage-2.6.yaml"
             bcftools: "{MODSDIR}/envs/bcftools-1.10.2.yaml"
             
         resources:

--- a/modules/sage/1.0/config/default.yaml
+++ b/modules/sage/1.0/config/default.yaml
@@ -10,6 +10,7 @@ lcr-modules:
         scratch_subdirectories: []
 
         # include here any additional flags to modify default parameters
+        # for example, use here "-validation_stringency LENIENT" if you encounter problems with bam files
         options:
             sage_run: ""
 

--- a/modules/sage/1.0/envs/hmftools-sage-2.2.yaml
+++ b/modules/sage/1.0/envs/hmftools-sage-2.2.yaml
@@ -1,1 +1,0 @@
-../../../../envs/hmftools/hmftools-sage-2.2.yaml

--- a/modules/sage/1.0/envs/hmftools-sage-2.6.yaml
+++ b/modules/sage/1.0/envs/hmftools-sage-2.6.yaml
@@ -1,0 +1,1 @@
+../../../../envs/hmftools/hmftools-sage-2.6.yaml

--- a/modules/sage/1.0/sage.smk
+++ b/modules/sage/1.0/sage.smk
@@ -111,14 +111,13 @@ rule _download_sage_references:
 # file for each genome build using file produced by reference_files workflow, and supply it as
 # a comma-deliminated list of chromosomes for SAGE run.
 def get_chromosomes(wildcards):
-    path = reference_files("genomes/"+str(wildcards.genome_build)+"/genome_fasta/main_chromosomes.txt")
-    input = str(path)
-    with open(input, 'r') as chromosome_file:
-        lines = chromosome_file.readlines()
-        chromosomes=[]
-        for x in lines:
-            chromosomes.append(x.rstrip("\n"))
-        chromosomes= ",".join(chromosomes)
+    chromosomes=[]
+    for i in range(1,23):
+        chromosomes.append(str(i))
+    chromosomes.append("X")
+    if "38" in str(wildcards.genome_build):
+        chromosomes = ["chr" + x for x in chromosomes]
+    chromosomes= ",".join(chromosomes)    
     return chromosomes
 
 # Variant calling rule

--- a/modules/sage/1.0/sage.smk
+++ b/modules/sage/1.0/sage.smk
@@ -64,8 +64,8 @@ rule _sage_input_bam:
         bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam",
         bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai"
     run:
-        op.relative_symlink(input.bam, output.bam)
-        op.relative_symlink(input.bam+ ".bai", output.bai)
+        op.absolute_symlink(input.bam, output.bam)
+        op.absolute_symlink(input.bam+ ".bai", output.bai)
 
 
 # Setup shared reference files. Symlinking these files to 00-inputs to ensure index and dictionary are present
@@ -74,8 +74,7 @@ rule _input_references:
     input: 
         genome_fa = reference_files("genomes/{genome_build}/genome_fasta/genome.fa"),
         genome_fai = reference_files("genomes/{genome_build}/genome_fasta/genome.fa.fai"),
-        genome_dict = reference_files("genomes/{genome_build}/genome_fasta/genome.dict"),
-        main_chromosomes = reference_files("genomes/{genome_build}/genome_fasta/main_chromosomes.txt")
+        genome_dict = reference_files("genomes/{genome_build}/genome_fasta/genome.dict")
     output: 
         genome_fa = CFG["dirs"]["inputs"] + "references/{genome_build}/genome.fa", 
         genome_fai = CFG["dirs"]["inputs"] + "references/{genome_build}/genome.fa.fai", 


### PR DESCRIPTION
It was found that mapping quality of not 0 for unmapped reads causes SAGE to exit with an error. This [was addressed](https://github.com/hartwigmedical/hmftools/issues/65) by developers in version 2.6, where flag `-validation_stringency` was added as an optional argument for SAGE. I am updating SAGE version used by this module to the latest release, so validation stringency can be set through the module config file.
In addition, it was found that if the user runs a dry run of lcr-modules right after installation, the function I used to restrict for standard chromosomes causes an error since it doesn't know that the file will be generated by snakemake. In this version, I modified the function to avoid this bug. 
Lastly, the symlinks for input files are now absolute instead of being relative.