### PR TITLE
Sequenza with cram support and Blacklist filtering

### DIFF
--- a/envs/bedtools/bedtools-2.29.2.yaml
+++ b/envs/bedtools/bedtools-2.29.2.yaml
@@ -1,0 +1,17 @@
+name: bedtools
+channels:
+  - bioconda
+  - conda-forge
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - bedtools=2.29.2
+  - bzip2=1.0.8
+  - coreutils=8.31
+  - libgcc-ng=9.3.0
+  - libgomp=9.3.0
+  - libstdcxx-ng=9.3.0
+  - xz=5.2.5
+  - zlib=1.2.11
+prefix: /home/dreval/miniconda3/envs/bedtools

--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -14,6 +14,7 @@ lcr-modules:
         scratch_subdirectories: ["seqz"]
         
         options:
+            # in bam2seqz pass any additional flags for the sequenza-utils. For example, this can include --normal2 to use for depth.ratio calculation.
             bam2seqz: "--qlimit 30"
             seqz_binning: "--window 300"
             cnv2igv: "--mode sequenza"
@@ -25,17 +26,19 @@ lcr-modules:
             bedtools: "{MODSDIR}/envs/bedtools-2.29.2.yaml"
             
         resources:
-            vecf_sort:
+            vcf_sort:
                 mem_mb: 2000
             bam2seqz:
                 mem_mb: 10000
                 bam: 1
-            merge_seqz: 
+                disk_mb: 10000
+            merge_seqz:
                 mem_mb: 10000
             filter_seqz:
                 mem_mb: 20000
             sequenza:
-                mem_mb: 20000     
+                mem_mb: 20000
+                disk_mb: 10000
         
         threads:
             bam2seqz: 3

--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -9,7 +9,7 @@ lcr-modules:
             merge_seqz: "{MODSDIR}/src/bash/merge_seqz.sh"
             filter_seqz: "{MODSDIR}/src/bash/filter_seqz.sh"
             run_sequenza: "{MODSDIR}/src/R/run_sequenza.R"
-            cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.0/cnv2igv.py"
+            cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.3/cnv2igv.py"
 
         scratch_subdirectories: ["seqz"]
         
@@ -21,21 +21,28 @@ lcr-modules:
         conda_envs:
             sequenza-utils: "{MODSDIR}/envs/sequenza-utils-3.0.0.yaml"
             r-sequenza: "{MODSDIR}/envs/r-sequenza-3.0.0.yaml"
-            cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.0/python-3.8.3.yaml"
+            cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.3/python-3.8.3.yaml"
             bedtools: "{MODSDIR}/envs/bedtools-2.29.2.yaml"
             
+        resources:
+            vecf_sort:
+                mem_mb: 2000
+            bam2seqz:
+                mem_mb: 10000
+                bam: 1
+            merge_seqz: 
+                mem_mb: 10000
+            filter_seqz:
+                mem_mb: 20000
+            sequenza:
+                mem_mb: 20000     
+        
         threads:
             bam2seqz: 3
             merge_seqz: 1
             filter_seqz: 1
             sequenza: 8 
 
-        mem_mb:
-            vcf_sort: 2000
-            bam2seqz: 10000
-            merge_seqz: 10000
-            filter_seqz: 20000
-            sequenza: 20000
 
         # For now, only supporting matched tumour-normal pairs
         pairing_config:

--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -22,6 +22,7 @@ lcr-modules:
             sequenza-utils: "{MODSDIR}/envs/sequenza-utils-3.0.0.yaml"
             r-sequenza: "{MODSDIR}/envs/r-sequenza-3.0.0.yaml"
             cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.0/python-3.8.3.yaml"
+            bedtools: "{MODSDIR}/envs/bedtools-2.29.2.yaml"
             
         threads:
             bam2seqz: 3

--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -11,7 +11,7 @@ lcr-modules:
             run_sequenza: "{MODSDIR}/src/R/run_sequenza.R"
             cnv2igv: "{SCRIPTSDIR}/cnv2igv/1.3/cnv2igv.py"
 
-        scratch_subdirectories: ["seqz"]
+        scratch_subdirectories: []
         
         options:
             # in bam2seqz pass any additional flags for the sequenza-utils. For example, this can include --normal2 to use for depth.ratio calculation.

--- a/modules/sequenza/1.4/envs/bedtools-2.29.2.yaml
+++ b/modules/sequenza/1.4/envs/bedtools-2.29.2.yaml
@@ -1,0 +1,1 @@
+../../../../envs/bedtools/bedtools-2.29.2.yaml

--- a/modules/sequenza/1.4/sequenza.smk
+++ b/modules/sequenza/1.4/sequenza.smk
@@ -90,7 +90,7 @@ rule _sequenza_input_dbsnp_pos:
     log:
         stderr = CFG["logs"]["inputs"] + "{genome_build}/sequenza_input_dbsnp_pos.stderr.log"
     resources:
-        mem_mb = CFG["mem_mb"]["vcf_sort"]
+        **CFG["resources"]["vcf_sort"]
     shell:
         op.as_one_line("""
         gzip -dc {input.vcf}
@@ -119,8 +119,7 @@ rule _sequenza_bam2seqz:
     threads:
         CFG["threads"]["bam2seqz"]
     resources:
-        mem_mb = CFG["mem_mb"]["bam2seqz"],
-	      bam = 1
+        **CFG["resources"]["bam2seqz"]    
     shell:
         op.as_one_line("""
         sequenza-utils bam2seqz {params.bam2seqz_opts} -gc {input.gc_wiggle} --fasta {input.genome} 
@@ -152,9 +151,10 @@ rule _sequenza_merge_seqz:
         seqz = CFG["dirs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/merged.binned.unfiltered.seqz.gz"
     log:
         stderr = CFG["logs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_merge_seqz.stderr.log"
-    threads: CFG["threads"]["merge_seqz"]
+    threads:
+        CFG["threads"]["merge_seqz"]
     resources: 
-        mem_mb = CFG["mem_mb"]["merge_seqz"]
+        **CFG["resources"]["merge_seqz"]  
     shell:
         op.as_one_line("""
         bash {input.merge_seqz} {input.seqz} 2>> {log.stderr}
@@ -178,7 +178,7 @@ rule _sequenza_filter_seqz:
     threads: 
         CFG["threads"]["filter_seqz"]
     resources: 
-        mem_mb = CFG["mem_mb"]["filter_seqz"]
+        **CFG["resources"]["filter_seqz"] 
     shell:
         op.as_one_line("""
         SEQZ_BLACKLIST_BED_FILES='{input.blacklist}'
@@ -202,9 +202,10 @@ rule _sequenza_run:
         stderr = CFG["logs"]["sequenza"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_run.{filter_status}.stderr.log"
     conda:
         CFG["conda_envs"]["r-sequenza"]
-    threads: CFG["threads"]["sequenza"]
+    threads:
+        CFG["threads"]["sequenza"]
     resources: 
-        mem_mb = CFG["mem_mb"]["sequenza"]
+        **CFG["resources"]["sequenza"] 
     shell:
         op.as_one_line("""
         Rscript {input.run_sequenza} {input.seqz} {input.assembly} {input.chroms} {input.x_chrom} 

--- a/modules/sequenza/1.4/sequenza.smk
+++ b/modules/sequenza/1.4/sequenza.smk
@@ -66,9 +66,9 @@ rule _sequenza_input_bam:
         bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bai",
         crai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.crai"
     run:
-        op.relative_symlink(input.bam, output.bam)
-        op.relative_symlink(input.bai, output.bai)
-        op.relative_symlink(input.bai, output.crai)
+        op.absolute_symlink(input.bam, output.bam)
+        op.absolute_symlink(input.bai, output.bai)
+        op.absolute_symlink(input.bai, output.crai)
 
 
 # Pulls in list of chromosomes for the genome builds

--- a/modules/sequenza/1.4/sequenza.smk
+++ b/modules/sequenza/1.4/sequenza.smk
@@ -15,6 +15,26 @@
 # Import package with useful functions for developing analysis modules
 import oncopipe as op
 
+
+# Check that the oncopipe dependency is up-to-date. Add all the following lines to any module that uses new features in oncopipe
+min_oncopipe_version="1.0.11"
+import pkg_resources
+try:
+    from packaging import version
+except ModuleNotFoundError:
+    sys.exit("The packaging module dependency is missing. Please install it ('pip install packaging') and ensure you are using the most up-to-date oncopipe version")
+
+# To avoid this we need to add the "packaging" module as a dependency for LCR-modules or oncopipe
+
+current_version = pkg_resources.get_distribution("oncopipe").version
+if version.parse(current_version) < version.parse(min_oncopipe_version):
+    print('\x1b[0;31;40m' + f'ERROR: oncopipe version installed: {current_version}' + '\x1b[0m')
+    print('\x1b[0;31;40m' + f"ERROR: This module requires oncopipe version >= {min_oncopipe_version}. Please update oncopipe in your environment" + '\x1b[0m')
+    sys.exit("Instructions for updating to the current version of oncopipe are available at https://lcr-modules.readthedocs.io/en/latest/ (use option 2)")
+
+# End of dependency checking section
+
+
 # Setup module and store module-specific configuration in `CFG`
 # `CFG` is a shortcut to `config["lcr-modules"]["sequenza"]`
 CFG = op.setup_module(
@@ -43,10 +63,12 @@ rule _sequenza_input_bam:
         bai = CFG["inputs"]["sample_bai"]
     output:
         bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam",
-        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bai"
+        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bai",
+        crai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.crai"
     run:
         op.relative_symlink(input.bam, output.bam)
         op.relative_symlink(input.bai, output.bai)
+        op.relative_symlink(input.bai, output.crai)
 
 
 # Pulls in list of chromosomes for the genome builds
@@ -98,7 +120,7 @@ rule _sequenza_bam2seqz:
         CFG["threads"]["bam2seqz"]
     resources:
         mem_mb = CFG["mem_mb"]["bam2seqz"],
-	bam = 1
+	      bam = 1
     shell:
         op.as_one_line("""
         sequenza-utils bam2seqz {params.bam2seqz_opts} -gc {input.gc_wiggle} --fasta {input.genome} 
@@ -145,16 +167,21 @@ rule _sequenza_filter_seqz:
     input:
         seqz = str(rules._sequenza_merge_seqz.output.seqz),
         filter_seqz = CFG["inputs"]["filter_seqz"],
-        dbsnp_pos = str(rules._sequenza_input_dbsnp_pos.output.pos)
+        dbsnp_pos = str(rules._sequenza_input_dbsnp_pos.output.pos),
+        blacklist = reference_files("genomes/{genome_build}/encode/encode-blacklist.{genome_build}.bed")
     output:
         seqz = CFG["dirs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/merged.binned.filtered.seqz.gz"
     log:
         stderr = CFG["logs"]["seqz"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/sequenza_filter_seqz.stderr.log"
-    threads: CFG["threads"]["filter_seqz"]
+    conda:
+        CFG["conda_envs"]["bedtools"]
+    threads: 
+        CFG["threads"]["filter_seqz"]
     resources: 
         mem_mb = CFG["mem_mb"]["filter_seqz"]
     shell:
         op.as_one_line("""
+        SEQZ_BLACKLIST_BED_FILES='{input.blacklist}'
         {input.filter_seqz} {input.seqz} {input.dbsnp_pos} 2>> {log.stderr}
             |
         gzip > {output.seqz} 2>> {log.stderr}
@@ -211,7 +238,7 @@ rule _sequenza_output_seg:
     output:
         seg = CFG["dirs"]["outputs"] + "{filter_status}_seg/{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}.igv.seg"
     run:
-        op.relative_symlink(input.seg, output.seg)
+        op.relative_symlink(input.seg, output.seg, in_module=True)
 
 
 # Generates the target sentinels for each run, which generate the symlinks

--- a/modules/sequenza/CHANGELOG.md
+++ b/modules/sequenza/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
-## [1.5] - 2021-01-17
+## [1.4] - 2021-01-17
 
 This release was authored by Kostiantyn Dreval.
 

--- a/modules/sequenza/CHANGELOG.md
+++ b/modules/sequenza/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to the `sequenza` module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [1.5] - 2021-01-17
+
+This release was authored by Kostiantyn Dreval.
+
+- This update includes several new features, such as: cram support, filtering of variants that falls in ENCODE blacklisted regions, version check of oncopipe module, and handling of input and output symlinks.
+
 ## [1.3] - 2020-07-17
 
 This release was authored by Bruno Grande.


### PR DESCRIPTION
This update for the existing sequenza module includes support of cram files, filtering of variants that fall within blacklisted regions, and harmonizing the module with recent updates (oncopipe version check, absolute symlinks for inputs, `in_module` symlinking for outputs, and resource unpacking). I have also removed the default scratch directory from config.
I have edited v1.4 files to ensure easy view of the changes that I implemented. Once approved, I will bump this to version 1.5 and restore v1.4 back.