### PR TITLE
Modules/slms 3/1.0

### DIFF
--- a/modules/manta/2.0/config/default.yaml
+++ b/modules/manta/2.0/config/default.yaml
@@ -6,6 +6,8 @@ lcr-modules:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_bam: null  # UPDATE
             sample_bai: null  # UPDATE
+
+        scripts:
             augment_manta_vcf: "{SCRIPTSDIR}/augment_manta_vcf/1.0/augment_manta_vcf.py"
 
         options:

--- a/modules/manta/2.0/manta.smk
+++ b/modules/manta/2.0/manta.smk
@@ -150,15 +150,15 @@ rule _manta_run:
 # and fixes the sample IDs in the VCF header to match sample IDs used in Snakemake
 rule _manta_augment_vcf:
     input:
-        variants_dir = rules._manta_run.output.variants_dir,
-        aug_vcf = CFG["inputs"]["augment_manta_vcf"]
+        variants_dir = rules._manta_run.output.variants_dir        
     output:
         vcf = CFG["dirs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{vcf_name}.augmented.vcf"
     log:
         stdout = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stdout.log",
         stderr = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stderr.log"
     params:
-        opts = CFG["options"]["augment_vcf"]
+        opts = CFG["options"]["augment_vcf"], 
+        aug_vcf = CFG["scripts"]["augment_manta_vcf"]
     conda:
         CFG["conda_envs"]["augment_manta_vcf"]
     threads:
@@ -167,7 +167,7 @@ rule _manta_augment_vcf:
         mem_mb = CFG["mem_mb"]["augment_vcf"]
     shell:
         op.as_one_line("""
-        {input.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
+        {params.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
         --vcf_type {wildcards.vcf_name} {input.variants_dir}/{wildcards.vcf_name}.vcf.gz {output.vcf}
         > {log.stdout} 2> {log.stderr}
         """)

--- a/modules/manta/2.1/config/default.yaml
+++ b/modules/manta/2.1/config/default.yaml
@@ -6,6 +6,8 @@ lcr-modules:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_bam: "__UPDATE__"
             sample_bai: "__UPDATE__"
+        
+        scripts: 
             augment_manta_vcf: "{SCRIPTSDIR}/augment_manta_vcf/1.0/augment_manta_vcf.py"
 
         options:

--- a/modules/manta/2.1/manta.smk
+++ b/modules/manta/2.1/manta.smk
@@ -150,15 +150,15 @@ rule _manta_run:
 # and fixes the sample IDs in the VCF header to match sample IDs used in Snakemake
 rule _manta_augment_vcf:
     input:
-        variants_dir = rules._manta_run.output.variants_dir,
-        aug_vcf = CFG["inputs"]["augment_manta_vcf"]
+        variants_dir = rules._manta_run.output.variants_dir        
     output:
         vcf = CFG["dirs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{vcf_name}.augmented.vcf"
     log:
         stdout = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stdout.log",
         stderr = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stderr.log"
     params:
-        opts = CFG["options"]["augment_vcf"]
+        opts = CFG["options"]["augment_vcf"], 
+        aug_vcf = CFG["scripts"]["augment_manta_vcf"]
     conda:
         CFG["conda_envs"]["augment_manta_vcf"]
     threads:
@@ -167,7 +167,7 @@ rule _manta_augment_vcf:
         mem_mb = CFG["mem_mb"]["augment_vcf"]
     shell:
         op.as_one_line("""
-        {input.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
+        {params.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
         --vcf_type {wildcards.vcf_name} {input.variants_dir}/{wildcards.vcf_name}.vcf.gz {output.vcf}
         > {log.stdout} 2> {log.stderr}
         """)

--- a/modules/manta/2.2/config/default.yaml
+++ b/modules/manta/2.2/config/default.yaml
@@ -6,6 +6,8 @@ lcr-modules:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_bam: "__UPDATE__"
             sample_bai: "__UPDATE__"
+
+        scripts:
             augment_manta_vcf: "{SCRIPTSDIR}/augment_manta_vcf/1.0/augment_manta_vcf.py"
 
         options:

--- a/modules/manta/2.2/manta.smk
+++ b/modules/manta/2.2/manta.smk
@@ -150,15 +150,15 @@ rule _manta_run:
 # and fixes the sample IDs in the VCF header to match sample IDs used in Snakemake
 rule _manta_augment_vcf:
     input:
-        variants_dir = str(rules._manta_run.output.variants_dir),
-        aug_vcf = CFG["inputs"]["augment_manta_vcf"]
+        variants_dir = str(rules._manta_run.output.variants_dir)        
     output:
         vcf = CFG["dirs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{vcf_name}.augmented.vcf"
     log:
         stdout = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stdout.log",
         stderr = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stderr.log"
     params:
-        opts = CFG["options"]["augment_vcf"]
+        opts = CFG["options"]["augment_vcf"], 
+        aug_vcf = CFG["scripts"]["augment_manta_vcf"]
     conda:
         CFG["conda_envs"]["augment_manta_vcf"]
     threads:
@@ -167,7 +167,7 @@ rule _manta_augment_vcf:
         mem_mb = CFG["mem_mb"]["augment_vcf"]
     shell:
         op.as_one_line("""
-        {input.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
+        {params.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
         --vcf_type {wildcards.vcf_name} {input.variants_dir}/{wildcards.vcf_name}.vcf.gz {output.vcf}
         > {log.stdout} 2> {log.stderr}
         """)

--- a/modules/manta/2.3/config/default.yaml
+++ b/modules/manta/2.3/config/default.yaml
@@ -6,6 +6,8 @@ lcr-modules:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_bam: "__UPDATE__"
             sample_bai: "__UPDATE__"
+
+        scripts: 
             augment_manta_vcf: "{SCRIPTSDIR}/augment_manta_vcf/1.1/augment_manta_vcf.py"
 
         options:

--- a/modules/manta/2.3/manta.smk
+++ b/modules/manta/2.3/manta.smk
@@ -153,15 +153,15 @@ rule _manta_run:
 # and fixes the sample IDs in the VCF header to match sample IDs used in Snakemake
 rule _manta_augment_vcf:
     input:
-        variants_dir = str(rules._manta_run.output.variants_dir),
-        aug_vcf = CFG["inputs"]["augment_manta_vcf"]
+        variants_dir = str(rules._manta_run.output.variants_dir)        
     output:
         vcf = CFG["dirs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{vcf_name}.augmented.vcf"
     log:
         stdout = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stdout.log",
         stderr = CFG["logs"]["augment_vcf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/manta_augment_vcf.{vcf_name}.stderr.log"
     params:
-        opts = CFG["options"]["augment_vcf"]
+        opts = CFG["options"]["augment_vcf"], 
+        aug_vcf = CFG["scripts"]["augment_manta_vcf"]
     conda:
         CFG["conda_envs"]["augment_manta_vcf"]
     threads:
@@ -170,7 +170,7 @@ rule _manta_augment_vcf:
         mem_mb = CFG["mem_mb"]["augment_vcf"]
     shell:
         op.as_one_line("""
-        {input.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
+        {params.aug_vcf} {params.opts} --tumour_id {wildcards.tumour_id} --normal_id {wildcards.normal_id} 
         --vcf_type {wildcards.vcf_name} {input.variants_dir}/{wildcards.vcf_name}.vcf.gz {output.vcf}
         > {log.stdout} 2> {log.stderr}
         """)

--- a/modules/slms_3/1.0/slms_3.smk
+++ b/modules/slms_3/1.0/slms_3.smk
@@ -426,7 +426,12 @@ rule _slms_3_output_vcf:
 # Generates the target sentinels for each run, which generate the symlinks
 rule _slms_3_all:
     input:
-        # rules._starfish_all.input, 
+        rules._manta_all.input,
+        rules._strelka_all.input, 
+        rules._lofreq_all.input, 
+        rules._sage_all.input,
+        rules._mutect2_all.input,
+        rules._starfish_all.input, 
         expand(
             [
                 str(rules._slms_3_output_vcf.output.isec_vcf),


### PR DESCRIPTION
This PR fixes a problem with Mutect2 VCF sample name replacement that occurred when the sample ID pulled from the BAM header contains a space (shockingly not uncommon). It also incorporates the full `all` input from each sub-module to ensure all the final `99-outputs` directories are properly populated. 

I've also rolled in a patch to all the Manta modules (version 2.0 or higher) that moves the `augment_manta_vcf.py` script from an input to a parameter to prevent re-running if the lcr-scripts directory moves or changes (see #166). 
