### PR TITLE
Ignore sigpro download rule.

### DIFF
--- a/workflows/reference_files/2.4/reference_files_header.smk
+++ b/workflows/reference_files/2.4/reference_files_header.smk
@@ -352,7 +352,7 @@ rule download_sdf:
 
 
 def get_matching_download_rules(file):
-    ignored_rules = ["download_genome_fasta", "download_sdf"]
+    ignored_rules = ["download_genome_fasta", "download_sdf", "download_sigprofiler_genome"]
     rule_names = [ r for r in dir(rules) if r.startswith("download_")]
     rule_names = [ r for r in rule_names if r not in ignored_rules ]
     rule_list = [ getattr(rules, name) for name in rule_names ]


### PR DESCRIPTION
Added `download_sigprofiler_genome` to `ignored_rules` list to bypass cvbio processing of the rules output since it's not needed.