### PR TITLE
Fixed a bug where vcf2maf would error out if the input VCF is empty

### DIFF
--- a/modules/vcf2maf/1.2/vcf2maf.smk
+++ b/modules/vcf2maf/1.2/vcf2maf.smk
@@ -91,7 +91,8 @@ rule _vcf2maf_run:
         --vep-data {input.vep_cache}
         --vep-path $vepPATH {params.opts}
         --custom-enst {params.custom_enst}
-        > {log.stdout} 2> {log.stderr}
+        > {log.stdout} 2> {log.stderr} &&
+        touch {output.vep}
         """)
 
 


### PR DESCRIPTION
If the input VCF is empty, vcf2maf will complete successfully (the resulting MAF will just contain the header), but because no `.vep.vcf` file is generated, snakemake thinks output files are missing, and exits. This just runs `touch` on the `.vep.vcf` file to ensure it exists at the end of the rule.