### PR TITLE
Create a unique input file symlink per input maf

### DIFF
--- a/modules/lymphgen/1.0/lymphgen.smk
+++ b/modules/lymphgen/1.0/lymphgen.smk
@@ -78,7 +78,7 @@ rule _lymphgen_input_maf:
     input:
         maf = CFG["inputs"]["sample_maf"]
     output:
-        maf = CFG["dirs"]["inputs"] + "maf/input.maf"
+        maf = CFG["dirs"]["inputs"] + "maf/" + outprefix + ".maf"
     run:
         op.relative_symlink(input.maf, output.maf)
 


### PR DESCRIPTION
Tiny patch for ease of running across multiple input maf files. 
