### PR TITLE
bug fix for unmatched samples

### DIFF
--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -1253,8 +1253,16 @@ def generate_runs(
                     f"config[‘unmatched_normal_ids’] is not excluded from the samples table"
                     )
                     quit()
-                elif num_matches >= 1:
+                elif num_matches == 1:
                     unmatched_normals[key] = Sample(*normal_row.squeeze())
+                elif num_matches > 1:
+                    print(
+                    f"There are {num_matches} {seq_type} samples matching "
+                    f"the normal ID {normal_id}. This means there are {num_matches} normal samples for {key} in "
+                    f"the samples table and it is not desired. Please ensure all sample_id, seq_type, "
+                    f"and genome_build combinations are unique."
+                    )
+                    quit()
             args_dict["unmatched_normals"] = unmatched_normals
         elif (
             "run_unpaired_tumours_with" in args_dict

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -1228,7 +1228,7 @@ def generate_runs(
             "run_unpaired_tumours_with" in args_dict
             and args_dict["run_unpaired_tumours_with"] == "unmatched_normal"
             and unmatched_normal_ids is not None
-            and seq_type in sample_seq_type["seq_type"]
+
         ):
             unmatched_normals = dict()
             for key, normal_id in unmatched_normal_ids.items():
@@ -1242,10 +1242,11 @@ def generate_runs(
                     (samples.sample_id == normal_id) & (samples.seq_type == seq_type)
                 ]
                 num_matches = len(normal_row)
-                assert num_matches == 1, (
-                    f"There are {num_matches} {seq_type} samples matching "
-                    f"the normal ID {normal_id} (instead of just one)."
-                )
+                if seq_type in sample_seq_type["seq_type"]:
+                    assert num_matches == 1, (
+                        f"There are {num_matches} {seq_type} samples matching "
+                        f"the normal ID {normal_id} (instead of just one)."
+                    )
                 unmatched_normals[key] = Sample(*normal_row.squeeze())
             args_dict["unmatched_normals"] = unmatched_normals
         elif (

--- a/oncopipe/oncopipe/__init__.py
+++ b/oncopipe/oncopipe/__init__.py
@@ -1253,7 +1253,6 @@ def generate_runs(
                     f"config[‘unmatched_normal_ids’] is not excluded from the samples table"
                     )
                     quit()
-                #if seq_type in sample_seq_type["seq_type"]:
                 elif num_matches >= 1:
                     unmatched_normals[key] = Sample(*normal_row.squeeze())
             args_dict["unmatched_normals"] = unmatched_normals


### PR DESCRIPTION
In the bug fix merged with PR #208 related to issue #204 we tested the update only in demo workflow setup. It worked with no issues, however once tried in GAMBL returned a different error:
```
AssertionError in line 43 of /projects/rmorin/projects/gambl-repos/gambl-kdreval/src/lcr-modules/modules/slms_3/1.0/slms_3.smk:
`run_unpaired_tumours_with` was set to 'unmatched_normal' whereas `unmatched_normal` and `unmatched_normals` were both None. For {seq_type!r}, provide an unmatched normal sample ID. See README for format.
 File "/projects/rmorin/projects/gambl-repos/gambl-kdreval/src/snakemake/run_slms_3_icgc_cram.smk", line 40, in <module>
 File "/projects/rmorin/projects/gambl-repos/gambl-kdreval/src/lcr-modules/modules/slms_3/1.0/slms_3.smk", line 43, in <module>
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 1668, in setup_module
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 1273, in generate_runs
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 1176, in walk_through_dict
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 1176, in walk_through_dict
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 1178, in walk_through_dict
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 1069, in generate_runs_for_patient_wrapper
 File "/home/kdreval/lcr-modules/oncopipe/oncopipe/__init__.py", line 999, in generate_runs_for_patient
```
It turned out that this worked because all samples in demo are matched, and there are no unmatched samples. 
I have tracked this error down and it needed to move the seq_type check to a different place. Since the part of code that evaluated unmatched normal ids
```
            "run_unpaired_tumours_with" in args_dict
            and args_dict["run_unpaired_tumours_with"] == "unmatched_normal"
            and unmatched_normal_ids is not None
            and seq_type in sample_seq_type["seq_type"]
```
is not evaluated because this check returns FALSE, this line never gets run:
`unmatched_normals[key] = Sample(*normal_row.squeeze())`
and is not included in the dictionary generated to store unmatched normals for a given seq_type--genome_build. It later causes the function generate_runs_for_patient, which uses generate_runs within it, to complain of no normal given :mag:
In this PR, the check for seq_type is moved to wrap the `assert` statement and is only evaluated if the seq_type is present in the sample table after subsetting. This has been tested both in demo (adding mock unmatched sample) and in GAMBL set up.