### PR TITLE
small bug fixes

### DIFF
--- a/modules/sage/1.0/sage.smk
+++ b/modules/sage/1.0/sage.smk
@@ -140,7 +140,6 @@ rule _run_sage:
         stderr = CFG["logs"]["sage"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/run_sage.stderr.log"
     params:
         opts = CFG["options"]["sage_run"],
-        #chromosomes = _get_chromosomes,
         assembly = lambda w: "hg38" if "38" in str({w.genome_build}) else "hg19",
         sage= "$(dirname $(readlink -e $(which SAGE)))/sage.jar",
         jvmheap = lambda wildcards, resources: int(resources.mem_mb * 0.8)

--- a/modules/slms_3/1.0/slms_3.smk
+++ b/modules/slms_3/1.0/slms_3.smk
@@ -247,8 +247,11 @@ rule _slms_3_annotate_sage_gnomad:
         bcftools annotate --threads {threads} 
         -a {input.gnomad} -c INFO/AF {input.vcf} | 
         awk 'BEGIN {{FS=OFS="\\t"}} {{ if ($1 !~ /^#/ && $8 !~ ";AF=") $8=$8";AF=0"; print $0; }}' | 
-        sed 's/{wildcards.tumour_id}/TUMOR/g' | 
-        sed 's/{wildcards.normal_id}/NORMAL/g' | 
+        perl -ne '$norm="{wildcards.normal_id}";
+                  $tum="{wildcards.tumour_id}";
+                  s/(\s)$tum(\s)/$1TUMOR$2/;
+                  s/(\s)$norm(\s)/$1NORMAL$2/;
+                  print;' |
         bcftools view -s "NORMAL,TUMOR" -i 'INFO/AF < 0.0001' -Oz -o {output.vcf} 2> {log.stderr} 
         &&
         tabix -p vcf {output.vcf} 2>> {log.stderr}

--- a/workflows/reference_files/2.4/reference_files_header.smk
+++ b/workflows/reference_files/2.4/reference_files_header.smk
@@ -75,12 +75,12 @@ for build_name, build_info in config["genome_builds"].items():
     assert "provider" in build_info and genome_provider in possible_providers, (
         f"`provider` not set for `{build_name}` or `provider` not among {possible_providers}."
     )
-    assert "genome_fasta_url" in build_info, f"`genome_fasta_url` not set for `{build_name}`."
-    url_code = urllib.request.urlopen(build_info["genome_fasta_url"]).getcode()
-    assert url_code == 200, (
-        f"Pinging `genome_fasta_url` for {build_name} returned HTTP code {url_code} "
-        f"(rather than 200): \n{build_info['genome_fasta_url']}"
-    )    
+    if "genome_fasta_url" in build_info:
+        url_code = urllib.request.urlopen(build_info["genome_fasta_url"]).getcode()
+        assert url_code == 200, (
+            f"Pinging `genome_fasta_url` for {build_name} returned HTTP code {url_code} "
+            f"(rather than 200): \n{build_info['genome_fasta_url']}"
+        )
     # Find the appropriate SDF file for this genome build
     if build_name not in SDF_IGNORE:
         SDF_GENOME_BUILDS.append(build_name)


### PR DESCRIPTION
Updates in this PR:

1. SLMS-3 rule `_slms_3_annotate_sage_gnomad` is modified to re-implement sample renaming that used sed with per approach. This allows for proper handling of the sample ids with special characters, for example `-`.
2. To address the issue #193 , the function `get_chromosomes` in SAGE module is removed and the chromosome list handling is re-implemented. The `main_chromosomes.txt` file generated by the reference_files is now an input, and the list of chromosomes is generated using bash tool `paste`,
3. In reference files, the `genome_fasta_url` was the required key for every genome build, because there is a check for the valid url link, which needs to return a valid ping. This interfered with functionality of using a locally-available fasta file, and in this PR the ping signal check is made conditional.