### PR TITLE
Updated CrossMap and chr-prefix handling; improved support for non-standard genome builds

### DIFF
--- a/modules/vcf2maf/1.3/config/default.yaml
+++ b/modules/vcf2maf/1.3/config/default.yaml
@@ -17,6 +17,8 @@ lcr-modules:
             #--cache-version  Version of offline cache to use with VEP (e.g. 75, 84, 91) [Default: Installed version]
             species: "homo_sapiens"
             gnomAD_cutoff: 0.001 # cut-off to be used for AF frequency of germline variants in gnomAD
+            target_builds: ["hg38", "grch38", "hg19", "grch37"]  # Target genome builds for chr-prefixing and CrossMap
+            reference_config: "__UPDATE__"  # Path to the reference workflow config file. Usef to handle reference genome builds;
         # here you can specify path to txt file with a list of custom ENST IDs that override canonical selection
         # it will be parsed to --custom-enst flag of vcf2maf
         # if no non-canonical transcript IDs to be included, leave switches empty

--- a/modules/vcf2maf/1.3/config/default.yaml
+++ b/modules/vcf2maf/1.3/config/default.yaml
@@ -24,9 +24,8 @@ lcr-modules:
         # if no non-canonical transcript IDs to be included, leave switches empty
         switches:
             custom_enst:
-              hg38: ""
+              grch38: ""
               grch37: ""
-              hs37d5: ""
 
         conda_envs:
             vcf2maf: "{MODSDIR}/envs/vcf2maf-1.6.18.yaml"

--- a/modules/vcf2maf/CHANGELOG.md
+++ b/modules/vcf2maf/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the `vcf2maf` module will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3] - 2022-02-23
+
+This release was kind of authored by Christopher Rushton. Someone else originally authored this release
+
+- Now supports automatic CrossMap/chr prefix changing for target genome builds for all input VCF files. For instance, an input VCF called against hg38-nci will now be used to generate a MAF file against both hg38 (no changes, chr-prefixed), GRCh38 (remove chr prefix), hg19 (CrossMap and chr-prefixed) and GRCh37 (CrossMap and chr-prefix). The reference workflow config is used to determine the "same" and "different" genome versions and chr prefixes. Also handles cases where CrossMap adds extra chr-prefixes to already prefixed output files, and updates the NCBI_Build column of the output MAF file.
+- Improved handling of non-standard genome versions
+- Updated custom ENST ID files to only require one per genome build version ("grch38" and "grch37")
+
+
 ## [1.2] - 2020-12-01
 
 This release was authored by Kostia Dreval


### PR DESCRIPTION
-All input VCFs are now annotated and converted to the desired genome builds and variants, adding or removing chr-prefixes as necessary. Note that output files which originated from CrossMap are placed in a different output directory. Variants and genome build "groups" are determined based on the reference config
- Updated handling of custom ENST ID files, to only require one per genome build type (ex. GRCh38 and GRCh37)
- Updated handling of unique genome builds (ex. hg19-reddy)

# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for New Module

## Checklist for Updated Module

Important! If you are updating the module version, ensure the previous version of the module is restored from master.
If you want to restore a deleted file or directory from the remote master, you can use `git checkout origin/master path/to/file`,
then a `git commit` will ensure that file is tracked on your branch again.
Example:
```
mv modules/strelka/1.1 modules/strelka/1.2
git checkout origin/master modules/strelka/1.1
```
