### PR TITLE
fastq accommodation: bam2fastq and tiny star fix

### DIFF
--- a/modules/bam2fastq/1.2/bam2fastq.smk
+++ b/modules/bam2fastq/1.2/bam2fastq.smk
@@ -43,7 +43,7 @@ CFG = op.setup_module(
     version = "1.2",
     subdirectories = ["inputs", "fastq", "outputs"],
 )
-
+print(CFG["samples"]["sample_id"].tolist())
 # Define rules to be run locally when using a compute cluster
 localrules:
     _bam2fastq_input_bam,
@@ -94,7 +94,7 @@ if CFG["temp_outputs"]:
             stdout = CFG["logs"]["fastq"] + "{seq_type}/{sample_id}/bam2fastq.stdout.log",
             stderr = CFG["logs"]["fastq"] + "{seq_type}/{sample_id}/bam2fastq.stderr.log"
         wildcard_constraints:
-            sample_id = "|".join(mrna_bams)
+           sample_id = "|".join(CFG["samples"]["sample_id"].tolist())
         params:
             opts = CFG["options"]["bam2fastq"]
         conda:

--- a/modules/bam2fastq/1.2/bam2fastq.smk
+++ b/modules/bam2fastq/1.2/bam2fastq.smk
@@ -43,7 +43,7 @@ CFG = op.setup_module(
     version = "1.2",
     subdirectories = ["inputs", "fastq", "outputs"],
 )
-print(CFG["samples"]["sample_id"].tolist())
+
 # Define rules to be run locally when using a compute cluster
 localrules:
     _bam2fastq_input_bam,

--- a/modules/bam2fastq/1.2/bam2fastq.smk
+++ b/modules/bam2fastq/1.2/bam2fastq.smk
@@ -93,6 +93,8 @@ if CFG["temp_outputs"]:
         log:
             stdout = CFG["logs"]["fastq"] + "{seq_type}/{sample_id}/bam2fastq.stdout.log",
             stderr = CFG["logs"]["fastq"] + "{seq_type}/{sample_id}/bam2fastq.stderr.log"
+        wildcard_constraints:
+            sample_id = "|".join(other_rna)
         params:
             opts = CFG["options"]["bam2fastq"]
         conda:

--- a/modules/bam2fastq/1.2/bam2fastq.smk
+++ b/modules/bam2fastq/1.2/bam2fastq.smk
@@ -94,7 +94,7 @@ if CFG["temp_outputs"]:
             stdout = CFG["logs"]["fastq"] + "{seq_type}/{sample_id}/bam2fastq.stdout.log",
             stderr = CFG["logs"]["fastq"] + "{seq_type}/{sample_id}/bam2fastq.stderr.log"
         wildcard_constraints:
-            sample_id = "|".join(other_rna)
+            sample_id = "|".join(mrna_bams)
         params:
             opts = CFG["options"]["bam2fastq"]
         conda:

--- a/modules/star/1.4/star.smk
+++ b/modules/star/1.4/star.smk
@@ -79,12 +79,12 @@ rule _star_input_fastq:
 def get_overhang(wildcards,build = False):
     tbl = config["lcr-modules"]["star"]["samples"]
     read_length = tbl.loc[(tbl.sample_id==wildcards.sample_id) & (tbl.seq_type == wildcards.seq_type), 'read_length'].values[0]
-    return(read_length - 1)
+    return(int(read_length - 1))
 
 def get_index(wildcards, build=False): 
     tbl = config["lcr-modules"]["star"]["samples"]
     read_length = tbl.loc[(tbl.sample_id==wildcards.sample_id) & (tbl.seq_type == wildcards.seq_type), 'read_length'].values[0]
-    overhang = (read_length - 1)
+    overhang = int(read_length - 1)
     gencode_release = config["lcr-modules"]["star"]["reference_params"]["gencode_release"]
     index = reference_files(expand("genomes/{{genome_build}}/star_index/star-2.7.3a/gencode-{release}/overhang-{overhang}",
         release = gencode_release, overhang = overhang

--- a/modules/star/1.4/star_grouped.smk
+++ b/modules/star/1.4/star_grouped.smk
@@ -82,12 +82,12 @@ def get_overhang(wildcards,build = False):
     tbl = config["lcr-modules"]["star"]["samples"]
     # read_length = tbl[(tbl.sample_id == wildcards.sample_id) & (tbl.seq_type == wildcards.seq_type)]["read_length"].values()[0]
     read_length = tbl.loc[(tbl.sample_id==wildcards.sample_id) & (tbl.seq_type == wildcards.seq_type), 'read_length'].values[0]
-    return(read_length - 1)
+    return(int(read_length - 1))
 
 def get_index(wildcards, build=False): 
     tbl = config["lcr-modules"]["star"]["samples"]
     read_length = tbl.loc[(tbl.sample_id==wildcards.sample_id) & (tbl.seq_type == wildcards.seq_type), 'read_length'].values[0]
-    overhang = (read_length - 1)
+    overhang = int(read_length - 1)
     gencode_release = config["lcr-modules"]["star"]["reference_params"]["gencode_release"]
     index = reference_files(expand("genomes/{{genome_build}}/star_index/star-2.7.3a/gencode-{release}/overhang-{overhang}",
         release = gencode_release, overhang = overhang


### PR DESCRIPTION
This PR includes:
1) Changes to constrain rule bam2fastq_run to only samples with bam files. The goal is to disregard samples that only have fastq files. 
2) Minor change to the star and star_grouped snakefiles to return the variable "overhang" as an integer rather than a float (149 vs 149.0). Returning a float triggers the creation of already existing star indices.

# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for New Module

### Required

- [ ] I used the cookiecutter template and updated the placeholder rules.

- [ ] The snakemake rules follow the [design guidelines](https://lcr-modules.readthedocs.io/en/latest/for_developers.html#module-rules). 

  - [ ] All references to the `rules` object (_e.g._ for input files) are wrapped with `str()`.

- [ ] Every rule in the module is either listed under `localrules` or has the `threads` and `resources` directives.

- [ ] Input and output files are being symlinked into the `CFG["inputs"]` and `CFG["outputs"]` subdirectories, respectively.

- [ ] I grouped the input symlinking rule to the next job that uses the input files. 

- [ ] I updated the final target rule (`*_all`) to include every output rule.

- [ ] I explained important module design decisions in `CHANGELOG.md`.

- [ ] I tested the module on real data for all supported `seq_type` values.

- [ ] I updated the `default.yaml` configuration file to provide default values for each rule in the module snakefile.

- [ ] I did not set any global wildcard constraints. Any/all wildcard constraints are set on a per-rule basis. 

- [ ] I ensured that all symbolic links are relative and self-contained (_i.e._ do not point outside of the repository).

- [ ] I replaced every value that should (or might need to) be updated in the default configuration file with `__UPDATE__`.

- [ ] I recursively searched for all comments containing `TODO` to ensure none were left. For example:

  ```bash
  grep -r TODO modules/<module_name>/1.0
  ```

### If applicable

- [ ] I added more granular output subdirectories.

- [ ] I added rules to the `reference_files` workflow to generate any new reference files.

- [ ] I added subdirectories with large intermediate files to the list of `scratch_subdirectories` in the `default.yaml` configuration file.

- [ ] I updated the list of available wildcards for the input files in the `default.yaml` configuration file.

## Checklist for Updated Module

Important! If you are updating the module version, ensure the previous version of the module is restored from master.
If you want to restore a deleted file or directory from the remote master, you can use `git checkout origin/master path/to/file`,
then a `git commit` will ensure that file is tracked on your branch again.
Example:
```
mv modules/strelka/1.1 modules/strelka/1.2
git checkout origin/master modules/strelka/1.1
```
