### PR TITLE
Bug fix: relative path interpretation

### DIFF
--- a/modules/vcf2maf/1.3/config/default.yaml
+++ b/modules/vcf2maf/1.3/config/default.yaml
@@ -13,7 +13,7 @@ lcr-modules:
             project_base: "__UPDATE__" # Full absolute path to prepend to blacklist_template above
             convert_coord: "{SCRIPTSDIR}/crossmap/1.0/convert_maf_coords.sh"
             augment_ssm: "{SCRIPTSDIR}/augment_ssm/1.0/augment_ssm.py"
-            deblacklisting: "{MODSDIR}/src/deblacklist_ssm.R"
+            deblacklisting: "src/deblacklist_ssm.R"
             gamblr_branch: "" # Leave blank unless you need to install from a specific branch from the GAMBLR repo (expert users only)
             gamblr_config_url: "https://raw.githubusercontent.com/morinlab/GAMBLR/master/config.yml"
             src_dir: "{MODSDIR}/src"

--- a/modules/vcf2maf/1.3/vcf2maf.smk
+++ b/modules/vcf2maf/1.3/vcf2maf.smk
@@ -50,6 +50,9 @@ VCF2MAF_GENOME_VERSION = {}  # Will be a simple {"GRCh38-SFU": "grch38"} etc.
 VCF2MAF_GENOME_PREFIX = {}  # Will be a simple hash of {"GRCh38-SFU": True} if chr-prefixed
 VCF2MAF_VERSION_MAP = {}
 
+# Interpret the absolute path to this script so it doesn't get interpreted relative to the module snakefile later. 
+AUGMENT_SSM = os.path.abspath(config["lcr-modules"]["vcf2maf"]["inputs"]["augment_ssm"])
+
 for genome_build, attributes in config['genome_builds'].items():
     try:
         genome_version = attributes["version"]
@@ -212,7 +215,7 @@ rule _vcf2maf_install_GAMBLR:
     shell:
         op.as_one_line("""
         wget -qO {output.config} {params.config_url} &&
-        R -q -e 'devtools::install_github("morinlab/GAMBLR"{params.branch})' 
+        R -q -e 'options(timeout=9999999); devtools::install_github("morinlab/GAMBLR"{params.branch})' 
         """)
 
 rule _vcf2maf_deblacklist_maf: 
@@ -302,7 +305,7 @@ rule _vcf2maf_augment_maf:
         filter = "|".join(["raw", "deblacklisted"]), 
         tumour_id = "|".join(MULTI_SAMPLES.tumour_sample_id.tolist())
     script:
-        config["lcr-modules"]["vcf2maf"]["inputs"]["augment_ssm"]
+        AUGMENT_SSM
 
 
 rule _vcf2maf_output_original: 


### PR DESCRIPTION
I forgot that Snakemake doesn't interpret all file paths relative to the directory where Snakemake is launched. So annoying. 
