### PR TITLE
Now generates additional output file excluding the A53 subgroup

### DIFF
--- a/modules/lymphgen/CHANGELOG.md
+++ b/modules/lymphgen/CHANGELOG.md
@@ -14,3 +14,9 @@ You can run LymphGen using just SNVs, or with CNV and SV data
 Note if you provide CNV and SV files, you should specify the appropriate column names in the config file
 All possible iterations of LymphGen will be run (i.e. if you provide both CNVs and SNVs, LymphGen will be run
 with both CNVs and SNVs, as well as just with SNVs)
+
+## [1.0] - 2022-05-10
+
+Additional improvements, authored by Chris "scienceparrot" Rushton.
+
+Add an additional iteration of LymphGen, which excludes the A53 subgroup from classification


### PR DESCRIPTION
Also added an additional "composite_other" file, which selects cases with >0.5 subgroup confidence which are still classified as "Other"

# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for New Module

### Required

- [x] I used the cookiecutter template and updated the placeholder rules.

- [x] The snakemake rules follow the [design guidelines](https://lcr-modules.readthedocs.io/en/latest/for_developers.html#module-rules). 

  - [ ] All references to the `rules` object (_e.g._ for input files) are wrapped with `str()`.

- [x] Every rule in the module is either listed under `localrules` or has the `threads` and `resources` directives.

- [x] Input and output files are being symlinked into the `CFG["inputs"]` and `CFG["outputs"]` subdirectories, respectively.

- [x] I grouped the input symlinking rule to the next job that uses the input files. 

- [x] I updated the final target rule (`*_all`) to include every output rule.

- [x] I explained important module design decisions in `CHANGELOG.md`.

- [x] I tested the module on real data for all supported `seq_type` values.

- [x] I updated the `default.yaml` configuration file to provide default values for each rule in the module snakefile.

- [x] I did not set any global wildcard constraints. Any/all wildcard constraints are set on a per-rule basis. 

- [x] I ensured that all symbolic links are relative and self-contained (_i.e._ do not point outside of the repository).

- [x] I replaced every value that should (or might need to) be updated in the default configuration file with `__UPDATE__`.

- [x] I recursively searched for all comments containing `TODO` to ensure none were left. For example:

  ```bash
  grep -r TODO modules/<module_name>/1.0
  ```

### If applicable

- [ ] I added more granular output subdirectories.

- [ ] I added rules to the `reference_files` workflow to generate any new reference files.

- [ ] I added subdirectories with large intermediate files to the list of `scratch_subdirectories` in the `default.yaml` configuration file.

- [ ] I updated the list of available wildcards for the input files in the `default.yaml` configuration file.

## Checklist for Updated Module

Important! If you are updating the module version, ensure the previous version of the module is restored from master.
If you want to restore a deleted file or directory from the remote master, you can use `git checkout origin/master path/to/file`,
then a `git commit` will ensure that file is tracked on your branch again.
Example:
```
mv modules/strelka/1.1 modules/strelka/1.2
git checkout origin/master modules/strelka/1.1
```
