### PR TITLE
IgBLAST reference files rules

### DIFF
--- a/workflows/reference_files/2.4/config/default.yaml
+++ b/workflows/reference_files/2.4/config/default.yaml
@@ -144,6 +144,9 @@ tools:
     bcftools:
         conda_env: "envs/bcftools-1.10.2.yaml"
         version: "1.10.2"
+    igblast:
+        conda_env: "envs/igblast-1.17.1.yaml"
+        version: "1.17.1"
 
 cvbio_config:
     gtf: 

--- a/workflows/reference_files/2.4/envs/igblast-1.17.1.yaml
+++ b/workflows/reference_files/2.4/envs/igblast-1.17.1.yaml
@@ -1,0 +1,19 @@
+name: igblast
+channels:
+  - bioconda
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - bzip2=1.0.8
+  - icu=58.2
+  - igblast=1.17.1
+  - libgcc-ng=9.3.0
+  - libgomp=9.3.0
+  - libstdcxx-ng=9.3.0
+  - libxml2=2.9.12
+  - ncbi-vdb=2.11.0
+  - perl=5.26.2
+  - xz=5.2.5
+  - zlib=1.2.11
+prefix: /home/mcruz/miniconda3/envs/igblast

--- a/workflows/reference_files/2.4/reference_files_header.smk
+++ b/workflows/reference_files/2.4/reference_files_header.smk
@@ -75,12 +75,6 @@ for build_name, build_info in config["genome_builds"].items():
     assert "provider" in build_info and genome_provider in possible_providers, (
         f"`provider` not set for `{build_name}` or `provider` not among {possible_providers}."
     )
-    if "genome_fasta_url" in build_info:
-        url_code = urllib.request.urlopen(build_info["genome_fasta_url"]).getcode()
-        assert url_code == 200, (
-            f"Pinging `genome_fasta_url` for {build_name} returned HTTP code {url_code} "
-            f"(rather than 200): \n{build_info['genome_fasta_url']}"
-        )
     # Find the appropriate SDF file for this genome build
     if build_name not in SDF_IGNORE:
         SDF_GENOME_BUILDS.append(build_name)


### PR DESCRIPTION
# Pull Request Checklists

- [x] I added rules to the `reference_files` workflow to generate any new reference files.

Added rules to:
- download required files for IgBLAST run
- download IMGT reference sequences for IG and TCR receptors
- convert IMGT sequences into format that can be passed to "makeblastdb" (function provided by igblast)
- make IgBLAST db from IMGT ref sequences
Also:
-  added igblast.yaml file in envs/ and updated the reference files config default.yaml to include the igblast environment
- removed URL code fetching lines from reference_files_header.smk that were causing snakemake to error out with a URLError

