### PR TITLE
Module/mutsig/1.0

### DIFF
--- a/envs/matlab/matlab.yaml
+++ b/envs/matlab/matlab.yaml
@@ -1,0 +1,13 @@
+name: matlab
+channels:
+  - cyclus
+  - anaconda
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - java-jre=8.45.14
+  - libgcc-ng=9.3.0
+  - libgomp=9.3.0
+  - ncurses=6.3
+prefix: /home/kdreval/miniconda3/envs/matlab

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -10,6 +10,7 @@ lcr-modules:
         seq_types: ["genome", "capture"]
         include_non_coding: True
         prepare_mafs: "{SCRIPTSDIR}/generate_smg_inputs/1.0/generate_smg_inputs.R"
+        src_dir: "{MODSDIR}/src/"
 
         scratch_subdirectories: []
 
@@ -23,10 +24,10 @@ lcr-modules:
             matlab: "{MODSDIR}/envs/matlab.yml"
 
         threads:
-            step_1: 4
+            mutsig: 2
 
         resources:
-            step_1:
+            mutsig:
                 mem_mb: 2000
 
         pairing_config:

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -6,6 +6,7 @@ lcr-modules:
         inputs:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             master_maf: "__UPDATE__"
+            sample_sets: "__UPDATE__"
         sample_set: ["__UPDATE__"]
         seq_types: ["genome", "capture"]
         include_non_coding: True

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -19,6 +19,8 @@ lcr-modules:
 
         conda_envs:
             salmon2counts: "{SCRIPTSDIR}/salmon2counts/1.0/salmon2counts.yaml"
+            wget: "{MODSDIR}/envs/wget-1.20.1.yml"
+            matlab: "{MODSDIR}/envs/matlab.yml"
 
         threads:
             step_1: 4

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -2,9 +2,8 @@ lcr-modules:
 
     mutsig:
 
-        # TODO: Update the list of available wildcards, if applicable
         inputs:
-            # Available wildcards: {seq_type} {genome_build} {sample_id}
+            # Available wildcards: {seq_type}
             master_maf: "__UPDATE__"
             sample_sets: "__UPDATE__"
         sample_set: ["__UPDATE__"]
@@ -14,10 +13,6 @@ lcr-modules:
         src_dir: "{MODSDIR}/src/"
 
         scratch_subdirectories: []
-
-        options:
-            step_1: ""
-            step_2: ""
 
         conda_envs:
             prepare_mafs: "{REPODIR}/envs/gatk/gatkR.yaml"

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -22,7 +22,7 @@ lcr-modules:
         conda_envs:
             salmon2counts: "{SCRIPTSDIR}/salmon2counts/1.0/salmon2counts.yaml"
             wget: "{MODSDIR}/envs/wget-1.20.1.yml"
-            matlab: "{MODSDIR}/envs/matlab.yml"
+            matlab: "{MODSDIR}/envs/matlab.yaml"
 
         threads:
             mutsig: 2

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -1,11 +1,15 @@
 lcr-modules:
-    
+
     mutsig:
 
         # TODO: Update the list of available wildcards, if applicable
         inputs:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
-            sample_maf: "__UPDATE__"
+            master_maf: "__UPDATE__"
+        sample_set: ["__UPDATE__"]
+        seq_types: ["genome", "capture"]
+        include_non_coding: True
+        prepare_mafs: "{SCRIPTSDIR}/generate_smg_inputs/1.0/generate_smg_inputs.R"
 
         scratch_subdirectories: []
 
@@ -14,15 +18,15 @@ lcr-modules:
             step_2: ""
 
         conda_envs:
-            samtools: "{MODSDIR}/envs/samtools-1.9.yaml"
-            
+            salmon2counts: "{SCRIPTSDIR}/salmon2counts/1.0/salmon2counts.yaml"
+
         threads:
             step_1: 4
 
         resources:
-            step_1: 
+            step_1:
                 mem_mb: 2000
-            
+
         pairing_config:
             genome:
                 run_paired_tumours: True

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -1,0 +1,34 @@
+lcr-modules:
+    
+    mutsig:
+
+        # TODO: Update the list of available wildcards, if applicable
+        inputs:
+            # Available wildcards: {seq_type} {genome_build} {sample_id}
+            sample_maf: "__UPDATE__"
+
+        scratch_subdirectories: []
+
+        options:
+            step_1: ""
+            step_2: ""
+
+        conda_envs:
+            samtools: "{MODSDIR}/envs/samtools-1.9.yaml"
+            
+        threads:
+            step_1: 4
+
+        resources:
+            step_1: 
+                mem_mb: 2000
+            
+        pairing_config:
+            genome:
+                run_paired_tumours: True
+                run_unpaired_tumours_with: "unmatched_normal"
+                run_paired_tumours_as_unpaired: False
+            capture:
+                run_paired_tumours: True
+                run_unpaired_tumours_with: "unmatched_normal"
+                run_paired_tumours_as_unpaired: False

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -21,7 +21,7 @@ lcr-modules:
 
         conda_envs:
             salmon2counts: "{SCRIPTSDIR}/salmon2counts/1.0/salmon2counts.yaml"
-            wget: "{MODSDIR}/envs/wget-1.20.1.yml"
+            wget: "{MODSDIR}/envs/wget-1.20.1.yaml"
             matlab: "{MODSDIR}/envs/matlab.yaml"
 
         threads:

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -24,7 +24,7 @@ lcr-modules:
 
         resources:
             mutsig:
-                mem_mb: 2000
+                mem_mb: 250000
 
         pairing_config:
             genome:

--- a/modules/mutsig/1.0/config/default.yaml
+++ b/modules/mutsig/1.0/config/default.yaml
@@ -20,7 +20,7 @@ lcr-modules:
             step_2: ""
 
         conda_envs:
-            salmon2counts: "{SCRIPTSDIR}/salmon2counts/1.0/salmon2counts.yaml"
+            prepare_mafs: "{REPODIR}/envs/gatk/gatkR.yaml"
             wget: "{MODSDIR}/envs/wget-1.20.1.yaml"
             matlab: "{MODSDIR}/envs/matlab.yaml"
 

--- a/modules/mutsig/1.0/envs/matlab.yaml
+++ b/modules/mutsig/1.0/envs/matlab.yaml
@@ -1,0 +1,1 @@
+../../../../envs/matlab/matlab.yaml

--- a/modules/mutsig/1.0/envs/samtools-1.9.yaml
+++ b/modules/mutsig/1.0/envs/samtools-1.9.yaml
@@ -1,0 +1,1 @@
+../../../../envs/samtools/samtools-1.9.yaml

--- a/modules/mutsig/1.0/envs/samtools-1.9.yaml
+++ b/modules/mutsig/1.0/envs/samtools-1.9.yaml
@@ -1,1 +1,0 @@
-../../../../envs/samtools/samtools-1.9.yaml

--- a/modules/mutsig/1.0/envs/wget-1.20.1.yaml
+++ b/modules/mutsig/1.0/envs/wget-1.20.1.yaml
@@ -1,0 +1,1 @@
+../../../../envs/wget/wget-1.20.1.yaml

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -41,12 +41,10 @@ if version.parse(current_version) < version.parse(min_oncopipe_version):
 CFG = op.setup_module(
     name = "mutsig",
     version = "1.0",
-    # TODO: If applicable, add more granular output subdirectories
     subdirectories = ["inputs", "mcr", "mutsig", "outputs"],
 )
 
 # Define rules to be run locally when using a compute cluster
-# TODO: Replace with actual rules once you change the rule names
 localrules:
     _mutsig_input_maf,
     _mutsig_step_2,
@@ -266,7 +264,6 @@ rule _mutsig_run:
 
 
 # Symlinks the final output files into the module results directory (under '99-outputs/')
-# TODO: If applicable, add an output rule for each file meant to be exposed to the user
 rule _mutsig_output_txt:
     input:
         txt = str(rules._mutsig_run.output.mutsig_sig_genes)
@@ -282,7 +279,6 @@ rule _mutsig_all:
         expand(
             [
                 str(rules._mutsig_output_txt.output.txt),
-                # TODO: If applicable, add other output rules here
             ],
             sample_set=CFG["sample_set"])
 

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -133,6 +133,9 @@ rule _mutsig_download_mcr:
     output:
         mcr_installer = temp(CFG["dirs"]["mcr"] + "MCR_R2013a_glnxa64_installer.zip"),
         local_mcr = directory(CFG["dirs"]["mcr"] + "local_mcr")
+    log:
+        stdout = CFG["logs"]["mcr"] + "download_mcr.stdout.log",
+        stderr = CFG["logs"]["mcr"] + "download_mcr.stderr.log"
     conda:
         CFG["conda_envs"]["wget"]
     shell:
@@ -142,6 +145,7 @@ rule _mutsig_download_mcr:
         https://ssd.mathworks.com/supportfiles/MCR_Runtime/R2013a/MCR_R2013a_glnxa64_installer.zip
             &&
         unzip {output.mcr_installer} -d $(dirname {output.mcr_installer})
+        > {log.stdout} 2> {log.stderr}
             &&
         mkdir {output.local_mcr}
         """)
@@ -153,6 +157,9 @@ rule _mutsig_install_mcr:
         mcr = str(rules._mutsig_download_mcr.output.mcr_installer)
     output:
         local_mcr = CFG["dirs"]["mcr"] + "install.success"
+    log:
+        stdout = CFG["logs"]["mcr"] + "install_mcr.stdout.log",
+        stderr = CFG["logs"]["mcr"] + "install_mcr.stderr.log"
     conda:
         CFG["conda_envs"]["matlab"]
     shell:
@@ -160,7 +167,8 @@ rule _mutsig_install_mcr:
         $(dirname {input.mcr})/install
         -mode silent
         -agreeToLicense yes
-        -destinationFolder $(dirname {output.local_mcr})
+        -destinationFolder $(dirname $(readlink -f {output.local_mcr}))
+        > {log.stdout} 2> {log.stderr}
             &&
         touch {output.local_mcr}
         """)

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -1,0 +1,147 @@
+#!/usr/bin/env snakemake
+
+
+##### ATTRIBUTION #####
+
+
+# Original Author:  Kostia Dreval
+# Module Author:    Kostia Dreval
+# Contributors:     N/A
+
+
+##### SETUP #####
+
+# Import package with useful functions for developing analysis modules
+import oncopipe as op
+
+# Check that the oncopipe dependency is up-to-date. Add all the following lines to any module that uses new features in oncopipe
+min_oncopipe_version="1.0.11"
+import pkg_resources
+try:
+    from packaging import version
+except ModuleNotFoundError:
+    sys.exit("The packaging module dependency is missing. Please install it ('pip install packaging') and ensure you are using the most up-to-date oncopipe version")
+
+# To avoid this we need to add the "packaging" module as a dependency for LCR-modules or oncopipe
+
+current_version = pkg_resources.get_distribution("oncopipe").version
+if version.parse(current_version) < version.parse(min_oncopipe_version):
+    print('\x1b[0;31;40m' + f'ERROR: oncopipe version installed: {current_version}' + '\x1b[0m')
+    print('\x1b[0;31;40m' + f"ERROR: This module requires oncopipe version >= {min_oncopipe_version}. Please update oncopipe in your environment" + '\x1b[0m')
+    sys.exit("Instructions for updating to the current version of oncopipe are available at https://lcr-modules.readthedocs.io/en/latest/ (use option 2)")
+
+# End of dependency checking section
+
+# Setup module and store module-specific configuration in `CFG`
+# `CFG` is a shortcut to `config["lcr-modules"]["mutsig"]`
+CFG = op.setup_module(
+    name = "mutsig",
+    version = "1.0",
+    # TODO: If applicable, add more granular output subdirectories
+    subdirectories = ["inputs", "mutsig", "outputs"],
+)
+
+# Define rules to be run locally when using a compute cluster
+# TODO: Replace with actual rules once you change the rule names
+localrules:
+    _mutsig_input_maf,
+    _mutsig_step_2,
+    _mutsig_output_tsv,
+    _mutsig_all,
+
+
+##### RULES #####
+
+
+# Symlinks the input files into the module results directory (under '00-inputs/')
+# TODO: If applicable, add an input rule for each input file used by the module
+# TODO: If applicable, create second symlink to .crai file in the input function, to accomplish cram support
+rule _mutsig_input_maf:
+    input:
+        maf = CFG["inputs"]["sample_maf"]
+    output:
+        maf = CFG["dirs"]["inputs"] + "maf/{seq_type}--{genome_build}/{sample_id}.maf"
+    group: 
+        "input_and_step_1"
+    run:
+        op.absolute_symlink(input.maf, output.maf)
+
+
+# Example variant calling rule (multi-threaded; must be run on compute server/cluster)
+# TODO: Replace example rule below with actual rule
+rule _mutsig_step_1:
+    input:
+        tumour_maf = CFG["dirs"]["inputs"] + "maf/{seq_type}--{genome_build}/{tumour_id}.maf",
+        normal_maf = CFG["dirs"]["inputs"] + "maf/{seq_type}--{genome_build}/{normal_id}.maf",
+        fasta = reference_files("genomes/{genome_build}/genome_fasta/genome.fa")
+    output:
+        tsv = CFG["dirs"]["mutsig"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/output.tsv"
+    log:
+        stdout = CFG["logs"]["mutsig"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/step_1.stdout.log",
+        stderr = CFG["logs"]["mutsig"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/step_1.stderr.log"
+    params:
+        opts = CFG["options"]["step_1"]
+    conda:
+        CFG["conda_envs"]["samtools"]
+    threads:
+        CFG["threads"]["step_1"]
+    resources:
+        **CFG["resources"]["step_1"]
+    group: 
+        "input_and_step_1"
+    shell:
+        op.as_one_line("""
+        <TODO> {params.opts} --tumour {input.tumour_maf} --normal {input.normal_maf}
+        --ref-fasta {input.fasta} --output {output.tsv} --threads {threads}
+        > {log.stdout} 2> {log.stderr}
+        """)
+
+
+# Example variant filtering rule (single-threaded; can be run on cluster head node)
+# TODO: Replace example rule below with actual rule
+rule _mutsig_step_2:
+    input:
+        tsv = str(rules._mutsig_step_1.output.tsv)
+    output:
+        tsv = CFG["dirs"]["mutsig"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/output.filt.tsv"
+    log:
+        stderr = CFG["logs"]["mutsig"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/step_2.stderr.log"
+    params:
+        opts = CFG["options"]["step_2"]
+    shell:
+        "grep {params.opts} {input.tsv} > {output.tsv} 2> {log.stderr}"
+
+
+# Symlinks the final output files into the module results directory (under '99-outputs/')
+# TODO: If applicable, add an output rule for each file meant to be exposed to the user
+rule _mutsig_output_tsv:
+    input:
+        tsv = str(rules._mutsig_step_2.output.tsv)
+    output:
+        tsv = CFG["dirs"]["outputs"] + "tsv/{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}.output.filt.tsv"
+    run:
+        op.relative_symlink(input.tsv, output.tsv, in_module= True)
+
+
+# Generates the target sentinels for each run, which generate the symlinks
+rule _mutsig_all:
+    input:
+        expand(
+            [
+                str(rules._mutsig_output_tsv.output.tsv),
+                # TODO: If applicable, add other output rules here
+            ],
+            zip,  # Run expand() with zip(), not product()
+            seq_type=CFG["runs"]["tumour_seq_type"],
+            genome_build=CFG["runs"]["tumour_genome_build"],
+            tumour_id=CFG["runs"]["tumour_sample_id"],
+            normal_id=CFG["runs"]["normal_sample_id"],
+            pair_status=CFG["runs"]["pair_status"])
+
+
+##### CLEANUP #####
+
+
+# Perform some clean-up tasks, including storing the module-specific
+# configuration on disk and deleting the `CFG` variable
+op.cleanup_module(CFG)

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -261,7 +261,7 @@ rule _mutsig_run:
         ../02-mutsig/{wildcards.sample_set}/
         > ../02-mutsig/{wildcards.sample_set}/log
             &&
-        touch {output.success}
+        touch ../02-mutsig/{wildcards.sample_set}/mutsig.success
         """)
 
 

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -93,7 +93,7 @@ rule _mutsig_prepare_maf:
         stdout = CFG["logs"]["inputs"] + "{sample_set}/prepare_maf.stdout.log",
         stderr = CFG["logs"]["inputs"] + "{sample_set}/prepare_maf.stderr.log"
     conda:
-        CFG["conda_envs"]["salmon2counts"]
+        CFG["conda_envs"]["prepare_mafs"]
     params:
         include_non_coding = str(CFG["include_non_coding"]).upper(),
         script = CFG["prepare_mafs"]

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -60,14 +60,22 @@ localrules:
 # Symlinks the input files into the module results directory (under '00-inputs/')
 rule _mutsig_input_maf:
     input:
-        maf = CFG["inputs"]["master_maf"],
-        sample_sets = CFG["inputs"]["sample_sets"]
+        maf = CFG["inputs"]["master_maf"]
     output:
-        maf = CFG["dirs"]["inputs"] + "maf/{seq_type}/input.maf",
-        sample_sets = CFG["dirs"]["inputs"] + "sample_sets/{seq_type}_sample_sets.tsv"
+        maf = CFG["dirs"]["inputs"] + "maf/{seq_type}/input.maf"
     run:
         op.absolute_symlink(input.maf, output.maf)
+
+
+# Symlinks the input files into the module results directory (under '00-inputs/')
+rule _mutsig_input_subsets:
+    input:
+        sample_sets = CFG["inputs"]["sample_sets"]
+    output:
+        sample_sets = CFG["dirs"]["inputs"] + "sample_sets/sample_sets.tsv"
+    run:
         op.absolute_symlink(input.sample_sets, output.sample_sets)
+
 
 # Prepare the maf file for the input to MutSig2CV
 rule _mutsig_prepare_maf:
@@ -77,7 +85,7 @@ rule _mutsig_prepare_maf:
                     allow_missing=True,
                     seq_type=CFG["seq_types"]
                     ),
-        sample_sets = str(rules._mutsig_input_maf.output.sample_sets)
+        sample_sets = str(rules._mutsig_input_subsets.output.sample_sets)
     output:
         maf = temp(CFG["dirs"]["inputs"] + "maf/{sample_set}.maf"),
         contents = CFG["dirs"]["inputs"] + "maf/{sample_set}.maf.content"
@@ -139,7 +147,7 @@ rule _mutsig_install_mcr:
     input:
         mcr = str(rules._mutsig_download_mcr.output.mcr_installer)
     output:
-        local_mcr = CFG["dirs"]["mcr"] + "local_mcr/install.success"
+        local_mcr = CFG["dirs"]["mcr"] + "install.success"
     conda:
         CFG["conda_envs"]["matlab"]
     shell:
@@ -174,7 +182,7 @@ rule _mutsig_configure_mcr:
         mcr_installed = str(rules._mutsig_install_mcr.output.local_mcr),
         mutsig = str(rules._mutsig_download_mutsig.output.mutsig)
     output:
-        local_mcr = CFG["dirs"]["mcr"] + "local_mcr/configure.success",
+        local_mcr = CFG["dirs"]["mcr"] + "configure.success",
         configured = MATLAB + "/lib/configure.success"
     conda:
         CFG["conda_envs"]["matlab"]

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -89,6 +89,9 @@ rule _mutsig_prepare_maf:
     output:
         maf = temp(CFG["dirs"]["inputs"] + "maf/{sample_set}.maf"),
         contents = CFG["dirs"]["inputs"] + "maf/{sample_set}.maf.content"
+    log:
+        stdout = CFG["logs"]["inputs"] + "{sample_set}/prepare_maf.stdout.log",
+        stderr = CFG["logs"]["inputs"] + "{sample_set}/prepare_maf.stderr.log"
     conda:
         CFG["conda_envs"]["salmon2counts"]
     params:
@@ -103,6 +106,7 @@ rule _mutsig_prepare_maf:
         {wildcards.sample_set}
         MutSig2CV
         {params.include_non_coding}
+        > {log.stdout} 2> {log.stderr}
         """)
 
 

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -87,7 +87,7 @@ rule _mutsig_prepare_maf:
                     allow_missing=True,
                     seq_type=CFG["seq_types"]
                     ),
-        sample_sets = str(rules._mutsig_input_subsets.output.sample_sets)
+        sample_sets = ancient(str(rules._mutsig_input_subsets.output.sample_sets))
     output:
         maf = temp(CFG["dirs"]["inputs"] + "maf/{sample_set}.maf"),
         contents = CFG["dirs"]["inputs"] + "maf/{sample_set}.maf.content"

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -47,9 +47,13 @@ CFG = op.setup_module(
 # Define rules to be run locally when using a compute cluster
 localrules:
     _mutsig_input_maf,
-    _mutsig_step_2,
+    _mutsig_input_subsets,
+    _mutsig_prepare_maf,
+    _mutsig_download_mutsig,
+    _mutsig_download_mcr,
+    _mutsig_configure_mcr,
     _mutsig_output_txt,
-    _mutsig_all,
+    _mutsig_all
 
 
 ##### RULES #####

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -100,6 +100,7 @@ rule _mutsig_prepare_maf:
         {input.maf}
         {input.sample_sets}
         $(dirname {output.maf})/
+        {wildcards.sample_set}
         MutSig2CV
         {params.include_non_coding}
         """)
@@ -204,7 +205,7 @@ rule _mutsig_configure_mcr:
             &&
         touch {output.configured}
             &&
-        ln -s {params.scripts_directory}/bash/run_Mutsig2CV.sh run_MutSig2CV.sh
+        ln -s {params.scripts_directory}bash/run_Mutsig2CV.sh run_MutSig2CV.sh
             &&
         ln -s $(dirname {output.configured})/libncurses.so.6 libncurses.so.5
             &&

--- a/modules/mutsig/1.0/mutsig.smk
+++ b/modules/mutsig/1.0/mutsig.smk
@@ -236,10 +236,10 @@ rule _mutsig_configure_mcr:
 # Actual MutSig2CV run
 rule _mutsig_run:
     input:
-        mcr = str(rules._mutsig_download_mcr.output.local_mcr),
-        mcr_installed = str(rules._mutsig_install_mcr.output.local_mcr),
-        mcr_configured = str(rules._mutsig_configure_mcr.output.local_mcr),
-        mutsig = str(rules._mutsig_download_mutsig.output.mutsig),
+        mcr = ancient(str(rules._mutsig_download_mcr.output.local_mcr)),
+        mcr_installed = ancient(str(rules._mutsig_install_mcr.output.local_mcr)),
+        mcr_configured = ancient(str(rules._mutsig_configure_mcr.output.local_mcr)),
+        mutsig = ancient(str(rules._mutsig_download_mutsig.output.mutsig)),
         maf = str(rules._mutsig_prepare_maf.output.maf)
     output:
         mutsig_maf = temp(CFG["dirs"]["mutsig"] + "{sample_set}/final_analysis_set.maf"),

--- a/modules/mutsig/1.0/schemas/base-1.0.yaml
+++ b/modules/mutsig/1.0/schemas/base-1.0.yaml
@@ -1,0 +1,1 @@
+../../../../schemas/base/base-1.0.yaml

--- a/modules/mutsig/1.0/src/bash/run_MutSig2CV.sh
+++ b/modules/mutsig/1.0/src/bash/run_MutSig2CV.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # script for execution of deployed applications
 #
-# Sets up the MATLAB Runtime environment for the current $ARCH and executes 
+# Sets up the MATLAB Runtime environment for the current $ARCH and executes
 # the specified command.
 #
 exe_name=$0
@@ -25,10 +25,10 @@ else
   args=
   while [ $# -gt 0 ]; do
       token=$1
-      args="${args} \"${token}\"" 
+      args="${args} \"${token}\""
       shift
   done
-  eval "\"${exe_dir}/MutSig2CV\"" $args
+  eval "\"${exe_dir}/MutSig2CV/mutsig2cv/MutSig2CV\"" $args
 fi
 exit
 

--- a/modules/mutsig/1.0/src/bash/run_MutSig2CV.sh
+++ b/modules/mutsig/1.0/src/bash/run_MutSig2CV.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# script for execution of deployed applications
+#
+# Sets up the MATLAB Runtime environment for the current $ARCH and executes 
+# the specified command.
+#
+exe_name=$0
+exe_dir=`dirname "$0"`
+echo "------------------------------------------"
+if [ "x$1" = "x" ]; then
+  echo Usage:
+  echo    $0 \<deployedMCRroot\> args
+else
+  echo Setting up environment variables
+  MCRROOT="$1"
+  echo ---
+  LD_LIBRARY_PATH=.:${MCRROOT}/runtime/glnxa64 ;
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/bin/glnxa64 ;
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/sys/os/glnxa64;
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:${MCRROOT}/sys/opengl/lib/glnxa64;
+  LD_LIBRARY_PATH=${LD_LIBRARY_PATH}:/home/kodreval/miniconda3/envs/matlab;
+  export LD_LIBRARY_PATH;
+  echo LD_LIBRARY_PATH is ${LD_LIBRARY_PATH};
+  shift 1
+  args=
+  while [ $# -gt 0 ]; do
+      token=$1
+      args="${args} \"${token}\"" 
+      shift
+  done
+  eval "\"${exe_dir}/MutSig2CV\"" $args
+fi
+exit
+

--- a/modules/mutsig/CHANGELOG.md
+++ b/modules/mutsig/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 This release was authored by Kostia Dreval.
 
-<!-- TODO: Explain each important module design decision below. -->
+- MutSig2CV module relies on the "master maf" file containing the mutation data for all samples,
+and a "sample_set" file where first column (sample_id or Tumor_Sample_Barcode) contains unique sample IDs,
+and each column sets the name of the sample subset to be included in the run. The column for each
+sample subset contains 1 if sample is a part of subset, or 0 if the sample is not part of the subset.
 
-- No module design decisions explained here yet.
+- Multiple input master maf files are allowed, for example when WGS and WES data are combined together.
+
+- MutSig2CV is picky about the running directory and where all reference files are expected to be without
+allowing user to modify or specify their location. This module will execute all runs in the `01-mcr` directory
+and is configured to follow the standard lcr-modules logich of output files, so the results for each sample subset
+are located in the `02-mutsig` directory and the main output is symlinked to `99-outputs`.
+
+- MutSig2CV saves maf as part of it's output. Due to space concerns and because maf files can easily become massive
+for large data sets, the maf files are meant to be temporary and are deleted upon completion of the module.
+
+- If the particular sample subset is modified to add or exclude samples, please create a new column in the
+sample_subsets file rather than modifying existing.

--- a/modules/mutsig/CHANGELOG.md
+++ b/modules/mutsig/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the `mutsig` module will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0] - 2022-06-13
+
+This release was authored by Kostia Dreval.
+
+<!-- TODO: Explain each important module design decision below. -->
+
+- No module design decisions explained here yet.


### PR DESCRIPTION
# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for New Module

### Required

- [X] I used the cookiecutter template and updated the placeholder rules.

- [X] The snakemake rules follow the [design guidelines](https://lcr-modules.readthedocs.io/en/latest/for_developers.html#module-rules). 

  - [X] All references to the `rules` object (_e.g._ for input files) are wrapped with `str()`.

- [X] Every rule in the module is either listed under `localrules` or has the `threads` and `resources` directives.

- [X] Input and output files are being symlinked into the `CFG["inputs"]` and `CFG["outputs"]` subdirectories, respectively.

- [ ] I grouped the input symlinking rule to the next job that uses the input files. 

- [X] I updated the final target rule (`*_all`) to include every output rule.

- [X] I explained important module design decisions in `CHANGELOG.md`.

- [X] I tested the module on real data for all supported `seq_type` values.

- [X] I updated the `default.yaml` configuration file to provide default values for each rule in the module snakefile.

- [X] I did not set any global wildcard constraints. Any/all wildcard constraints are set on a per-rule basis. 

- [X] I ensured that all symbolic links are relative and self-contained (_i.e._ do not point outside of the repository).

- [X] I replaced every value that should (or might need to) be updated in the default configuration file with `__UPDATE__`.

- [X] I recursively searched for all comments containing `TODO` to ensure none were left. For example:

  ```bash
  grep -r TODO modules/<module_name>/1.0
  ```

### If applicable

- [X] I added more granular output subdirectories.

- [ ] I added rules to the `reference_files` workflow to generate any new reference files.

- [ ] I added subdirectories with large intermediate files to the list of `scratch_subdirectories` in the `default.yaml` configuration file.

- [X] I updated the list of available wildcards for the input files in the `default.yaml` configuration file.
