### PR TITLE
Maf2maf support for variant re-annotation in vcf2maf module

### DIFF
--- a/modules/vcf2maf/1.3/config/default.yaml
+++ b/modules/vcf2maf/1.3/config/default.yaml
@@ -23,6 +23,7 @@ lcr-modules:
             # --filter-vcf     A VCF for FILTER tag common_variant. Set to 0 to disable [~/.vep/ExAC_nonTCGA.r0.3.1.sites.vep.vcf.gz]
             #--species        Ensembl-friendly name of species (e.g. mus_musculus for mouse) [homo_sapiens]
             #--cache-version  Version of offline cache to use with VEP (e.g. 75, 84, 91) [Default: Installed version]
+            maf2maf: "--cache-version 86 --species homo_sapiens --retain-cols gnomAD_AF,gnomADg_AF"
             species: "homo_sapiens"
             gnomAD_cutoff: 0.001 # cut-off to be used for AF frequency of germline variants in gnomAD
             target_builds: ["hg38", "grch38", "hg19", "grch37"]  # Target genome builds for chr-prefixing and CrossMap
@@ -50,6 +51,7 @@ lcr-modules:
             
         threads:
             vcf2maf: 12
+            maf2maf: 4
             annotate: 4
             deblacklist: 1
             augment: 12
@@ -58,6 +60,9 @@ lcr-modules:
             vcf2maf: 
                 mem_mb: 12000
                 vcf: 1
+            maf2maf: 
+                mem_mb: 12000
+                maf: 1
             augment: 
                 mem_mb: 12000
                 augment: 1

--- a/modules/vcf2maf/1.3/src/maf2maf.pl
+++ b/modules/vcf2maf/1.3/src/maf2maf.pl
@@ -1,0 +1,410 @@
+#!/usr/bin/env perl
+
+# maf2maf - Reannotate the effects of variants in a MAF by running maf2vcf followed by vcf2maf
+
+use strict;
+use warnings;
+use IO::File;
+use Getopt::Long qw( GetOptions );
+use Pod::Usage qw( pod2usage );
+use File::Temp qw( tempdir );
+use File::Copy qw( move );
+use File::Path qw( mkpath );
+use Config;
+
+# Set any default paths and constants
+my ( $tum_depth_col, $tum_rad_col, $tum_vad_col ) = qw( t_depth t_ref_count t_alt_count );
+my ( $nrm_depth_col, $nrm_rad_col, $nrm_vad_col ) = qw( n_depth n_ref_count n_alt_count );
+my ( $vep_path, $vep_data, $vep_forks, $buffer_size, $any_allele ) = ( "$ENV{HOME}/miniconda3/bin", "$ENV{HOME}/.vep", 4, 5000, 0 );
+my ( $ref_fasta, $filter_vcf ) = ( "$ENV{HOME}/.vep/homo_sapiens/102_GRCh37/Homo_sapiens.GRCh37.dna.toplevel.fa.gz", "" );
+my ( $species, $ncbi_build, $cache_version, $maf_center, $max_subpop_af ) = ( "homo_sapiens", "GRCh37", "", ".", 0.0004 );
+my $perl_bin = $Config{perlpath};
+
+# Columns that can be safely borrowed from the input MAF
+my $retain_cols = "Center,Verification_Status,Validation_Status,Mutation_Status,Sequencing_Phase" .
+    ",Sequence_Source,Validation_Method,Score,BAM_file,Sequencer,Tumor_Sample_UUID" .
+    ",Matched_Norm_Sample_UUID";
+
+# Columns that should never be overridden since they are results of re-annotation
+my %force_new_cols = map{ my $c = lc; ( $c, 1 )} qw( Hugo_Symbol Entrez_Gene_Id NCBI_Build
+    Chromosome Start_Position End_Position Strand Variant_Classification Variant_Type
+    Reference_Allele Tumor_Seq_Allele1 Tumor_Seq_Allele2 dbSNP_RS Tumor_Sample_Barcode
+    Matched_Norm_Sample_Barcode Match_Norm_Seq_Allele1 Match_Norm_Seq_Allele2
+    Tumor_Validation_Allele1 Tumor_Validation_Allele2 Match_Norm_Validation_Allele1
+    Match_Norm_Validation_Allele2 HGVSc HGVSp HGVSp_Short Transcript_ID Exon_Number t_depth
+    t_ref_count t_alt_count n_depth n_ref_count n_alt_count all_effects Allele Gene Feature
+    Feature_type Consequence cDNA_position CDS_position Protein_position Amino_acids Codons
+    Existing_variation ALLELE_NUM DISTANCE STRAND_VEP SYMBOL SYMBOL_SOURCE HGNC_ID BIOTYPE CANONICAL
+    CCDS ENSP SWISSPROT TREMBL UNIPARC RefSeq SIFT PolyPhen EXON INTRON DOMAINS AF AFR_AF
+    AMR_AF ASN_AF EAS_AF EUR_AF SAS_AF AA_AF EA_AF CLIN_SIG SOMATIC PUBMED MOTIF_NAME
+    MOTIF_POS HIGH_INF_POS MOTIF_SCORE_CHANGE IMPACT PICK VARIANT_CLASS TSL HGVS_OFFSET PHENO
+    MINIMISED ExAC_AF ExAC_AF_AFR ExAC_AF_AMR ExAC_AF_EAS ExAC_AF_FIN ExAC_AF_NFE ExAC_AF_OTH
+    ExAC_AF_SAS GENE_PHENO FILTER flanking_bps variant_id variant_qual ExAC_AF_Adj ExAC_AC_AN_Adj
+    ExAC_AC_AN ExAC_AC_AN_AFR ExAC_AC_AN_AMR ExAC_AC_AN_EAS ExAC_AC_AN_FIN ExAC_AC_AN_NFE
+    ExAC_AC_AN_OTH ExAC_AC_AN_SAS ExAC_FILTER gnomAD_AF gnomAD_AFR_AF gnomAD_AMR_AF gnomAD_ASJ_AF
+    gnomAD_EAS_AF gnomAD_FIN_AF gnomAD_NFE_AF gnomAD_OTH_AF gnomAD_SAS_AF );
+
+# Check for missing or crappy arguments
+unless( @ARGV and $ARGV[0]=~m/^-/ ) {
+    pod2usage( -verbose => 0, -message => "$0: Missing or invalid arguments!\n", -exitval => 2 );
+}
+
+# Parse options and print usage syntax on a syntax error, or if help was explicitly requested
+my ( $man, $help ) = ( 0, 0 );
+my ( $input_maf, $output_maf, $tmp_dir, $custom_enst_file );
+GetOptions(
+    'help!' => \$help,
+    'man!' => \$man,
+    'input-maf=s' => \$input_maf,
+    'output-maf=s' => \$output_maf,
+    'tmp-dir=s' => \$tmp_dir,
+    'tum-depth-col=s' => \$tum_depth_col,
+    'tum-rad-col=s' => \$tum_rad_col,
+    'tum-vad-col=s' => \$tum_vad_col,
+    'nrm-depth-col=s' => \$nrm_depth_col,
+    'nrm-rad-col=s' => \$nrm_rad_col,
+    'nrm-vad-col=s' => \$nrm_vad_col,
+    'retain-cols=s' => \$retain_cols,
+    'custom-enst=s' => \$custom_enst_file,
+    'vep-path=s' => \$vep_path,
+    'vep-data=s' => \$vep_data,
+    'vep-forks=s' => \$vep_forks,
+    'buffer-size=i' => \$buffer_size,
+    'any-allele!' => \$any_allele,
+    'species=s' => \$species,
+    'ncbi-build=s' => \$ncbi_build,
+    'cache-version=s' => \$cache_version,
+    'ref-fasta=s' => \$ref_fasta,
+    'max-subpop-af=f' => \$max_subpop_af
+) or pod2usage( -verbose => 1, -input => \*DATA, -exitval => 2 );
+pod2usage( -verbose => 1, -input => \*DATA, -exitval => 0 ) if( $help );
+pod2usage( -verbose => 2, -input => \*DATA, -exitval => 0 ) if( $man );
+
+# Locate the maf2vcf and vcf2maf scripts that should be next to this script
+my ( $script_dir ) = $0 =~ m/^(.*)\/maf2maf/;
+$script_dir = "." unless( $script_dir );
+my ( $maf2vcf_path, $vcf2maf_path ) = ( "$script_dir/maf2vcf.pl", "$script_dir/vcf2maf.pl" );
+( -s $maf2vcf_path ) or die "ERROR: Couldn't locate maf2vcf.pl! Must be beside maf2maf.pl\n";
+( -s $vcf2maf_path ) or die "ERROR: Couldn't locate vcf2maf.pl! Must be beside maf2maf.pl\n";
+
+# Check if required arguments are missing or problematic
+( defined $input_maf ) or die "ERROR: --input-maf must be defined!\n";
+( -s $input_maf ) or die "ERROR: Provided --input-maf is missing or empty: $input_maf\n";
+( -s $ref_fasta ) or die "ERROR: Provided --ref-fasta is missing or empty: $ref_fasta\n";
+( $input_maf !~ m/\.(gz|bz2|bcf)$/ ) or die "ERROR: Unfortunately, --input-maf cannot be in a compressed format\n";
+
+# Create a temporary directory for our intermediate files, unless the user wants to use their own
+if( $tmp_dir ) {
+    mkpath( $tmp_dir );
+}
+else {
+    $tmp_dir = tempdir( CLEANUP => 1 );
+}
+
+# Construct a maf2vcf command and run it
+my $maf2vcf_cmd = "$perl_bin $maf2vcf_path --input-maf $input_maf --output-dir $tmp_dir " .
+    "--ref-fasta $ref_fasta --tum-depth-col $tum_depth_col --tum-rad-col $tum_rad_col " .
+    "--tum-vad-col $tum_vad_col --nrm-depth-col $nrm_depth_col --nrm-rad-col $nrm_rad_col ".
+    "--nrm-vad-col $nrm_vad_col --per-tn-vcfs";
+system( $maf2vcf_cmd ) == 0 or die "\nERROR: Failed to run maf2vcf! Command: $maf2vcf_cmd\n";
+
+my $tmp_basename = "$tmp_dir/" . substr( $input_maf, rindex( $input_maf, '/' ) + 1 );
+$tmp_basename =~ s/(\.)?(maf|tsv|txt)?$//;
+my $vcf_file = $tmp_basename . ".vcf";
+my $vep_anno = $tmp_basename . ".vep.vcf";
+
+# Skip running VEP if a VEP-annotated VCF already exists
+if( -s $vep_anno ) {
+    warn "WARNING: Annotated VCF already exists ($vep_anno). Skipping re-annotation.\n";
+}
+else {
+    warn "STATUS: Running VEP and writing to: $vep_anno\n";
+    # Make sure we can find the VEP script
+    my $vep_script = ( -s "$vep_path/vep" ? "$vep_path/vep" : "$vep_path/variant_effect_predictor.pl" );
+    ( -s $vep_script ) or die "ERROR: Cannot find VEP script in path: $vep_path\n";
+
+    # Contruct VEP command using some default options and run it
+    my $vep_cmd = "$perl_bin $vep_script --species $species --assembly $ncbi_build --offline --no_progress --no_stats --buffer_size $buffer_size --sift b --ccds --uniprot --hgvs --symbol --numbers --domains --gene_phenotype --canonical --protein --biotype --uniprot --tsl --pubmed --variant_class --shift_hgvs 1 --check_existing --total_length --allele_number --no_escape --xref_refseq --failed 1 --vcf --flag_pick_allele --pick_order canonical,tsl,biotype,rank,ccds,length --dir $vep_data --fasta $ref_fasta --format vcf --input_file $vcf_file --output_file $vep_anno";
+    # VEP barks if --fork is set to 1. So don't use this argument unless it's >1
+    $vep_cmd .= " --fork $vep_forks" if( $vep_forks > 1 );
+    # Require allele match for co-located variants unless user-rejected or we're using a newer VEP
+    $vep_cmd .= " --check_allele" unless( $any_allele or $vep_script =~ m/vep$/ );
+    # Add --cache-version only if the user specifically asked for a version
+    $vep_cmd .= " --cache_version $cache_version" if( $cache_version );
+    # Add options that only work on human variants
+    if( $species eq "homo_sapiens" ) {
+        # Slight change in these arguments if using the newer VEP
+        $vep_cmd .= " --polyphen b " . ( $vep_script =~ m/vep$/ ? "--af --af_1kg --af_esp --af_gnomad" : "--gmaf --maf_1kg --maf_esp" );
+    }
+    # Add options that work for most species, except a few
+    $vep_cmd .= " --regulatory" unless( $species eq "canis_familiaris" );
+
+    # Make sure it ran without error codes
+    system( $vep_cmd ) == 0 or die "\nERROR: Failed to run the VEP annotator! Command: $vep_cmd\n";
+    ( -s $vep_anno ) or warn "WARNING: VEP-annotated VCF file is missing or empty: $vep_anno\n";
+}
+
+# Load the tumor-normal pairs from the TSV created by maf2vcf
+my $tsv_file = $tmp_basename . ".pairs.tsv";
+
+# Store the VEP annotated VCF header so we can duplicate it for per-TN VCFs
+my $vep_vcf_header = `grep ^## $vep_anno`;
+
+# Split the multi-sample VEP annotated VCF into per-TN VCFs
+my ( %tn_pair, %t_col_idx, %n_col_idx, %tn_vep );
+my $vep_fh = IO::File->new( $vep_anno ) or die "ERROR: Couldn't open file: $vep_anno\n";
+while( my $line = $vep_fh->getline ) {
+
+    # Skip comment lines, but parse everything else including the column headers
+    next if( $line =~ m/^##/ );
+    my @cols = map{s/^\s+|\s+$|\r|\n//g; $_} split( /\t/, $line );
+
+    # Parse the header line to map column names to their indexes
+    if( $line =~ m/^#CHROM/ ) {
+
+        # Initialize VCF header and fill up %tn_pair for each tumor-normal pair
+        foreach ( `grep -Ev ^# $tsv_file` ){
+            chomp;
+            my @ids = split( "\t", $_ );
+            $t_col_idx{ $ids[ 0 ] } = 1;
+            $n_col_idx{ $ids[ 1 ] } = 1;
+            # If the same tumor is paired with different normals, treat them as separate TN-pairs
+            $tn_pair{ $ids[ 0 ] }{ $ids[ 1 ] } = 1;
+            my $tn_vcf_file = "$tmp_dir/$ids[0]\_vs_$ids[1].vep.vcf";
+            $tn_vep{ $tn_vcf_file } = $vep_vcf_header . "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t$ids[0]\t$ids[1]\n";
+        }
+        # Save VCF column indexes of tumors and normals in %t_col_idx and %n_col_idx, respectively.
+        foreach my $idx ( 9..$#cols ){
+            my $id = $cols[ $idx ];
+            $t_col_idx{ $id } = $idx if( exists $t_col_idx{ $id } );
+            $n_col_idx{ $id } = $idx if( exists $n_col_idx{ $id } );
+        }
+    }
+    # For all other lines containing variants, cache it for the appropriate per-TN VCF
+    else {
+        my $GT_idx;
+        my @format_keys = split( /\:/, $cols[8] );
+        map{ $GT_idx = $_ if( $format_keys[ $_ ] eq "GT" ) } ( 0..$#format_keys );
+        # Look for non-null normal genotypes
+        my @n_cols;
+        foreach my $n_id ( keys %n_col_idx ){
+            my $n_idx = $n_col_idx{ $n_id };
+            next if( $n_idx < 9 );
+            my @n_info = split( /\:/, $cols[ $n_idx ] );
+            ( $n_info[ $GT_idx ] eq './.' ) or push @n_cols, $n_id;
+        }
+
+        foreach my $t_id ( keys %t_col_idx ){
+            my $t_idx = $t_col_idx{ $t_id };
+            next if( $t_idx < 9 );
+            my @t_info = split( /\:/, $cols[ $t_idx ] );
+            # Skip variants for TN-pairs where the tumor genotype is null
+            next if ( $t_info[ $GT_idx ] eq './.' );
+
+            # Otherwise write it to the appropriate per-TN VCF file
+            foreach my $n_id ( @n_cols ){
+                my $n_idx = $n_col_idx{ $n_id };
+                my $tn_vcf_file = "$tmp_dir/$t_id\_vs_$n_id.vep.vcf";
+                $tn_vep{ $tn_vcf_file } .= join( "\t", @cols[0..8,$t_idx,$n_idx] ) . "\n" if( exists $tn_pair{ $t_id }{ $n_id } );
+            }
+        }
+    }
+}
+
+# Write the cached contents of per-TN annotated VCFs into files
+foreach my $tn_vcf_file ( keys %tn_vep ) {
+    my $tn_vep_fh = IO::File->new( $tn_vcf_file, ">" ) or die "ERROR: Couldn't open file: $tn_vcf_file\n";
+    $tn_vep_fh->print( $tn_vep{$tn_vcf_file} );
+    $tn_vep_fh->close;
+}
+
+# For each annotated VCF generated above, contruct a vcf2maf command and run it
+my @vcfs = grep{ !m/$tmp_basename/ } glob( "$tmp_dir/*.vep.vcf" );
+foreach my $tn_vcf ( @vcfs ) {
+    my ( $tumor_id, $normal_id ) = $tn_vcf=~m/^.*\/(.*)_vs_(.*)\.vep.vcf/;
+    my $tn_maf = $tn_vcf;
+    $tn_maf =~ s/.vep.vcf$/.vep.maf/;
+    my $vcf2maf_cmd = "$perl_bin $vcf2maf_path --input-vcf $tn_vcf --output-maf $tn_maf --inhibit-vep" .
+        " --tumor-id $tumor_id --normal-id $normal_id --vep-path $vep_path --vep-data $vep_data" .
+        " --ref-fasta $ref_fasta --ncbi-build $ncbi_build --species $species";
+    $vcf2maf_cmd .= " --custom-enst $custom_enst_file" if( $custom_enst_file );
+    system( $vcf2maf_cmd ) == 0 or die "\nERROR: Failed to run vcf2maf! Command: $vcf2maf_cmd\n";
+}
+
+# Fetch the column header from one of the resulting MAFs
+my @mafs = glob( "$tmp_dir/*.vep.maf" );
+my $maf_header = `grep ^Hugo_Symbol $mafs[0] | head -n1`;
+chomp( $maf_header );
+
+# If user wants to retain some columns from the input MAF, fetch those and override
+my %input_maf_data = ();
+if( $retain_cols ) {
+
+    # Parse the input MAF and fetch the data for columns that we need to retain/override
+    my $input_maf_fh = IO::File->new( $input_maf ) or die "ERROR: Couldn't open --input-maf\n";
+    my %input_maf_col_idx = (); # Hash to map column names to column indexes
+    while( my $line = $input_maf_fh->getline ) {
+
+        next if( $line =~ m/^#/ ); # Skip comments
+
+        # Do a thorough removal of carriage returns, line feeds, prefixed/suffixed whitespace
+        my @cols = map{s/^\s+|\s+$|\r|\n//g; $_} split( /\t/, $line );
+
+        # Parse the header line to map column names to their indexes
+        if( $line =~ m/^(Hugo_Symbol|Chromosome|Tumor_Sample_Barcode)/i ) {
+            my $idx = 0;
+            map{ my $c = lc; $input_maf_col_idx{$c} = $idx; ++$idx } @cols;
+
+            # Check for columns to retain that are not in old MAF, or columns we shouldn't override in new MAF
+            foreach my $c ( split( ",", $retain_cols )) {
+                my $c_lc = lc( $c );
+                if( !defined $input_maf_col_idx{$c_lc} ) {
+                    warn "WARNING: Column '$c' not found in old MAF.\n";
+                }
+                elsif( $force_new_cols{$c_lc} ) {
+                    warn "WARNING: Column '$c' cannot be overridden in new MAF.\n";
+                }
+            }
+        }
+        else {
+            # Extract minimal variant info, and figure out which of the tumor alleles is non-REF
+            my ( $chr, $pos, $ref, $al1, $al2, $sample_id ) = map{ my $c = lc; ( defined $input_maf_col_idx{$c} ? $cols[$input_maf_col_idx{$c}] : "" ) } qw( Chromosome Start_Position Reference_Allele Tumor_Seq_Allele1 Tumor_Seq_Allele2 Tumor_Sample_Barcode );
+            # Prefer Tumor_Seq_Allele2 over Tumor_Seq_Allele1 if both are non-REF
+            my $var = (( defined $al2 and $al2 and $al2 ne $ref ) ? $al2 : $al1 );
+
+            # Remove (only one) prefixed reference bp from alleles, using "-" for simple indels
+            if( $ref and $var and substr( $ref, 0, 1 ) eq substr( $var, 0, 1 ) and $ref ne $var ) {
+                ( $ref, $var ) = map{$_ = substr( $_, 1 ); ( $_ ? $_ : "-" )} ( $ref, $var );
+                ++$pos unless( $ref eq "-" );
+            }
+
+            # Create a key for this variant using Chromosome:Start_Position:Tumor_Sample_Barcode:Reference_Allele:Variant_Allele
+            my $key = join( ":", $chr, $pos, $sample_id, $ref, $var );
+            %{$input_maf_data{$key}} = ();
+
+            # Store values for this variant into a hash, adding column names to the key
+            foreach my $c ( map{lc} split( ",", $retain_cols )) {
+                if( defined $input_maf_col_idx{$c} and defined $cols[$input_maf_col_idx{$c}] ) {
+                    $input_maf_data{$key}{$c} = $cols[$input_maf_col_idx{$c}];
+                }
+            }
+        }
+    }
+    $input_maf_fh->close;
+
+    # Add additional column headers for the output MAF, if any
+    my %maf_cols = map{ my $c = lc; ( $c, 1 )} split( /\t/, $maf_header );
+    my @addl_maf_cols = grep{ my $c = lc; !$maf_cols{$c} } split( ",", $retain_cols );
+    map{ $maf_header .= "\t$_" } @addl_maf_cols;
+
+    # Retain/override data in each of the per-TN-pair MAFs
+    foreach my $tn_maf ( @mafs ) {
+        my $tn_maf_fh = IO::File->new( $tn_maf ) or die "ERROR: Couldn't open file: $tn_maf\n";
+        my %output_maf_col_idx = (); # Hash to map column names to column indexes
+        my $tmp_tn_maf_fh = IO::File->new( "$tn_maf.tmp", ">" ) or die "ERROR: Couldn't open file: $tn_maf.tmp\n";
+        while( my $line = $tn_maf_fh->getline ) {
+
+            # Do a thorough removal of carriage returns, line feeds, prefixed/suffixed whitespace
+            my @cols = map{ s/^\s+|\s+$|\r|\n//g; $_ } split( /\t/, $line );
+
+            # Copy comment lines to the new MAF unchanged
+            if( $line =~ m/^#/ ) {
+                $tmp_tn_maf_fh->print( $line );
+            }
+            # Print the MAF header prepared earlier, but also create a hash with column indexes
+            elsif( $line =~ m/^Hugo_Symbol/ ) {
+                my $idx = 0;
+                map{ my $c = lc; $output_maf_col_idx{$c} = $idx; ++$idx } ( @cols, @addl_maf_cols );
+                $tmp_tn_maf_fh->print( "$maf_header\n" );
+            }
+            # For all other lines, insert the data collected from the original input MAF
+            else {
+                my $key = join( ":", map{ my $c = lc; $cols[$output_maf_col_idx{$c}] } qw( Chromosome Start_Position Tumor_Sample_Barcode Reference_Allele Tumor_Seq_Allele2 ));
+                foreach my $c ( map{lc} split( /\t/, $maf_header )){
+                    if( !$force_new_cols{$c} ) {
+                        $cols[$output_maf_col_idx{$c}] = $input_maf_data{$key}{$c} if( defined $input_maf_data{$key}{$c} );
+                    }
+                }
+                $tmp_tn_maf_fh->print( join( "\t", @cols ) . "\n" );
+            }
+        }
+        $tmp_tn_maf_fh->close;
+        $tn_maf_fh->close;
+
+        # Overwrite the old MAF with the new one containing data from the original input MAF
+        move( "$tn_maf.tmp", $tn_maf );
+    }
+}
+
+# Concatenate the per-TN-pair MAFs into the user-specified final MAF
+# Default to printing to screen if an output MAF was not defined
+my $maf_fh = *STDOUT;
+if( $output_maf ) {
+    $maf_fh = IO::File->new( $output_maf, ">" ) or die "ERROR: Couldn't open --output-maf\n";
+}
+$maf_fh->print( "$maf_header\n" );
+foreach my $tn_maf ( @mafs ) {
+    my @maf_lines = `grep -Ev "^#|^Hugo_Symbol" $tn_maf`;
+    $maf_fh->print( @maf_lines );
+}
+$maf_fh->close;
+
+__DATA__
+
+=head1 NAME
+
+ maf2maf.pl - Reannotate the effects of variants in a MAF by running maf2vcf followed by vcf2maf
+
+=head1 SYNOPSIS
+
+ perl maf2maf.pl --help
+ perl maf2maf.pl --input-maf test.maf --output-maf test.vep.maf
+
+=head1 OPTIONS
+
+ --input-maf      Path to input file in MAF format
+ --output-maf     Path to output MAF file [Default: STDOUT]
+ --tmp-dir        Folder to retain intermediate VCFs/MAFs after runtime [Default: usually /tmp]
+ --tum-depth-col  Name of MAF column for read depth in tumor BAM [t_depth]
+ --tum-rad-col    Name of MAF column for reference allele depth in tumor BAM [t_ref_count]
+ --tum-vad-col    Name of MAF column for variant allele depth in tumor BAM [t_alt_count]
+ --nrm-depth-col  Name of MAF column for read depth in normal BAM [n_depth]
+ --nrm-rad-col    Name of MAF column for reference allele depth in normal BAM [n_ref_count]
+ --nrm-vad-col    Name of MAF column for variant allele depth in normal BAM [n_alt_count]
+ --retain-cols    Comma-delimited list of columns to retain from the input MAF [Center,Verification_Status,Validation_Status,Mutation_Status,Sequencing_Phase,Sequence_Source,Validation_Method,Score,BAM_file,Sequencer,Tumor_Sample_UUID,Matched_Norm_Sample_UUID]
+ --custom-enst    List of custom ENST IDs that override canonical selection
+ --vep-path       Folder containing the vep script [~/miniconda3/bin]
+ --vep-data       VEP's base cache/plugin directory [~/.vep]
+ --vep-forks      Number of forked processes to use when running VEP [4]
+ --buffer-size    Number of variants VEP loads at a time; Reduce this for low memory systems [5000]
+ --any-allele     When reporting co-located variants, allow mismatched variant alleles too
+ --max-subpop-af  Add FILTER tag common_variant if gnomAD reports any subpopulation AFs greater than this [0.0004]
+ --species        Ensembl-friendly name of species (e.g. mus_musculus for mouse) [homo_sapiens]
+ --ncbi-build     NCBI reference assembly of variants in MAF (e.g. GRCm38 for mouse) [GRCh37]
+ --cache-version  Version of offline cache to use with VEP (e.g. 75, 84, 91) [Default: Installed version]
+ --ref-fasta      Reference FASTA file [~/.vep/homo_sapiens/102_GRCh37/Homo_sapiens.GRCh37.dna.toplevel.fa.gz]
+ --help           Print a brief help message and quit
+ --man            Print the detailed manual
+
+=head1 DESCRIPTION
+
+This script runs a given MAF through maf2vcf to generate per-TN-pair VCFs in a temporary folder, and then runs vcf2maf on each VCF to reannotate variant effects and create a new combined MAF
+
+=head2 Relevant links:
+
+ Homepage: https://github.com/ckandoth/vcf2maf
+ VCF format: http://samtools.github.io/hts-specs/
+ MAF format: https://docs.gdc.cancer.gov/Data/File_Formats/MAF_Format
+ VEP: http://ensembl.org/info/docs/tools/vep/index.html
+ VEP annotated VCF format: http://ensembl.org/info/docs/tools/vep/vep_formats.html#vcfout
+
+=head1 AUTHORS
+
+ Cyriac Kandoth (ckandoth@gmail.com)
+ Qingguo Wang (josephw10000@gmail.com)
+
+=head1 LICENSE
+
+ Apache-2.0 | Apache License, Version 2.0 | https://www.apache.org/licenses/LICENSE-2.0
+
+=cut

--- a/modules/vcf2maf/1.3/src/maf2vcf.pl
+++ b/modules/vcf2maf/1.3/src/maf2vcf.pl
@@ -1,0 +1,385 @@
+#!/usr/bin/env perl
+
+# maf2vcf - Reformat variants in a given MAF into generic VCFs with GT:AD:DP data if available
+
+use strict;
+use warnings;
+use IO::File;
+use Getopt::Long qw( GetOptions );
+use Pod::Usage qw( pod2usage );
+
+# Set any default paths and constants
+my $ref_fasta = "$ENV{HOME}/.vep/homo_sapiens/91_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz";
+my ( $tum_depth_col, $tum_rad_col, $tum_vad_col ) = qw( t_depth t_ref_count t_alt_count );
+my ( $nrm_depth_col, $nrm_rad_col, $nrm_vad_col ) = qw( n_depth n_ref_count n_alt_count );
+
+# Find out if samtools is properly installed, and warn the user if it's not
+my ( $samtools ) = map{chomp; $_}`which samtools`;
+( $samtools and -e $samtools ) or die "ERROR: Please install samtools, and make sure it's in your PATH\n";
+
+# Check for missing or crappy arguments
+unless( @ARGV and $ARGV[0]=~m/^-/ ) {
+    pod2usage( -verbose => 0, -message => "$0: Missing or invalid arguments!\n", -exitval => 2 );
+}
+
+# Parse options and print usage syntax on a syntax error, or if help was explicitly requested
+my ( $man, $help, $per_tn_vcfs ) = ( 0, 0, 0 );
+my ( $input_maf, $output_dir, $output_vcf );
+GetOptions(
+    'help!' => \$help,
+    'man!' => \$man,
+    'input-maf=s' => \$input_maf,
+    'output-dir=s' => \$output_dir,
+    'output-vcf=s' => \$output_vcf,
+    'ref-fasta=s' => \$ref_fasta,
+    'per-tn-vcfs!' => \$per_tn_vcfs,
+    'tum-depth-col=s' => \$tum_depth_col,
+    'tum-rad-col=s' => \$tum_rad_col,
+    'tum-vad-col=s' => \$tum_vad_col,
+    'nrm-depth-col=s' => \$nrm_depth_col,
+    'nrm-rad-col=s' => \$nrm_rad_col,
+    'nrm-vad-col=s' => \$nrm_vad_col
+) or pod2usage( -verbose => 1, -input => \*DATA, -exitval => 2 );
+pod2usage( -verbose => 1, -input => \*DATA, -exitval => 0 ) if( $help );
+pod2usage( -verbose => 2, -input => \*DATA, -exitval => 0 ) if( $man );
+
+# Check if required arguments are missing or problematic, fix as needed
+( defined $input_maf and defined $output_dir ) or die "ERROR: --input-maf and --output-dir must be defined!\n";
+( -s $ref_fasta ) or die "ERROR: Provided Reference FASTA is missing or empty! Path: $ref_fasta\n";
+unless( defined $output_vcf ) {
+    $output_vcf = "$output_dir/" . substr( $input_maf, rindex( $input_maf, '/' ) + 1 );
+    $output_vcf =~ s/(\.)?(maf|tsv|txt)?$/.vcf/;
+}
+
+# Before anything, let's parse the headers of this supposed "MAF-like" file and do some checks
+my $maf_fh = IO::File->new( $input_maf ) or die "ERROR: Couldn't open input MAF: $input_maf!\n";
+my ( %uniq_regions, %filter_tags, %flanking_bps, @tn_pair, %col_idx, $header_line );
+while( my $line = $maf_fh->getline ) {
+
+    # If the file uses Mac OS 9 newlines, quit with an error
+    ( $line !~ m/\r$/ ) or die "ERROR: Your MAF uses CR line breaks, which we can't support. Please use LF or CRLF.\n";
+
+    # Skip comment lines
+    next if( $line =~ m/^#/ );
+
+    # Instead of a chomp, do a thorough removal of carriage returns, line feeds, and prefixed/suffixed whitespace
+    my @cols = map{s/^\s+|\s+$|\r|\n//g; $_} split( /\t/, $line );
+
+    # Parse the header line to map column names to their indexes
+    if( $line =~ m/^(Hugo_Symbol|Chromosome|Tumor_Sample_Barcode)/i ) {
+
+        # Fetch the column names and do some sanity checks (don't be case-sensitive)
+        my $idx = 0;
+        $header_line = $line;
+        map{ my $c = lc; $col_idx{$c} = $idx; ++$idx; } @cols;
+        map{ my $c = lc; ( defined $col_idx{$c} ) or die "ERROR: $_ is a required MAF column!\n" } qw( Chromosome Start_Position Reference_Allele Tumor_Sample_Barcode );
+        ( defined $col_idx{tumor_seq_allele1} or defined $col_idx{tumor_seq_allele2} ) or die "ERROR: At least one MAF column for Tumor_Seq_Allele must be defined!\n";
+
+        # Fetch all tumor-normal paired IDs from the MAF, doing some whitespace cleanup in the same step
+        my $tn_idx = $col_idx{tumor_sample_barcode} + 1;
+        $tn_idx .= ( "," . ( $col_idx{matched_norm_sample_barcode} + 1 )) if( defined $col_idx{matched_norm_sample_barcode} );
+        @tn_pair = map{s/^\s+|\s+$|\r|\n//g; s/\s*\t\s*/\t/; $_}`grep -aEiv "^#|^Hugo_Symbol|^Chromosome|^Tumor_Sample_Barcode" $input_maf | cut -f $tn_idx | sort -u`;
+
+        # Quit if one of the TN barcodes are missing, or they contain characters not allowed in Unix filenames
+        map{ ( !m/^\s*$|^#|\0|\// ) or die "ERROR: Invalid Tumor_Sample_Barcode in MAF: \"$_\"\n"} @tn_pair;
+        next; # Code below is only for lines with variants
+    }
+
+    # Print an error if we got to this point without parsing a header line
+    ( %col_idx ) or die "ERROR: Couldn't find a header line (must start with Hugo_Symbol, Chromosome, or Tumor_Sample_Barcode): $input_maf\n";
+
+    # For each variant in the MAF, parse out the locus for running samtools faidx later
+    my ( $chr, $pos, $ref, $filter ) = map{ my $c = lc; ( defined $col_idx{$c} ? $cols[$col_idx{$c}] : "" )} qw( Chromosome Start_Position Reference_Allele FILTER );
+    $ref =~ s/^(\?|-|0)+$//; # Blank out the dashes (or other weird chars) used with indels
+    my $region = "$chr:" . ( $pos - 1 ) . "-" . ( $pos + length( $ref ));
+    $uniq_regions{$region} = 1;
+    # Also track the unique FILTER tags seen, so we can construct VCF header lines for each
+    map{ $filter_tags{$_} = 1 unless( $_ eq "PASS" or $_ eq "." )} split( /,|;/, $filter );
+}
+$maf_fh->close;
+
+# samtools runs faster when passed many loci at a time, but limited to around 125k args at least on
+# CentOS6. If there are too many loci, let's split them into smaller chunks and run separately
+my ( @regions_split, $lines );
+my @regions = keys %uniq_regions;
+push( @regions_split, [ splice( @regions, 0, 5000 ) ] ) while @regions;
+map{ my $loci = join( " ", @{$_} ); $lines .= `$samtools faidx $ref_fasta $loci` } @regions_split;
+foreach my $line ( grep( length, split( ">", $lines ))) {
+    # Carefully split this FASTA entry, properly chomping newlines for long indels
+    my ( $locus, $bps ) = split( "\n", $line, 2 );
+    $bps =~ s/\r|\n//g;
+    if( $bps ){
+        $bps = uc( $bps );
+        $flanking_bps{$locus} = $bps;
+    }
+}
+
+# If flanking_bps is entirely empty, then it's most likely that the user chose the wrong ref-fasta
+( %flanking_bps ) or die "ERROR: Make sure that ref-fasta is the same genome build as your MAF: $ref_fasta\n";
+
+# Create VCF header lines for the reference FASTA, its contigs, and their lengths
+my $ref_fai = $ref_fasta . ".fai";
+`$samtools faidx $ref_fasta` unless( -s $ref_fai );
+my @ref_contigs = map { chomp; my ($chr, $len)=split("\t"); "##contig=<ID=$chr,length=$len>\n" } `cut -f1,2 $ref_fai | sort -k1,1V`;
+my $ref_header = "##reference=file://$ref_fasta\n" . join( "", @ref_contigs );
+
+# Parse through each variant in the MAF, and fill up the respective per-sample VCFs
+$maf_fh = IO::File->new( $input_maf ) or die "ERROR: Couldn't open file: $input_maf\n";
+my %tn_vcf = (); # In-memory cache to speed up writing per-TN pair VCFs
+my $skipped_fh; # If any variants have ref mismatch issues, skip and store them separately
+my ( @var_key, %var_frmt, %var_fltr, %var_id, %var_qual ); # Retain variant info for printing later
+my %vcf_col_idx = (); # Tracks the position of genotype columns for each sample
+my $line_count = 0;
+
+while( my $line = $maf_fh->getline ) {
+
+    # Skip comment lines
+    next if( $line =~ m/^#/ );
+
+    # Instead of a chomp, do a thorough removal of carriage returns, line feeds, and prefixed/suffixed whitespace
+    my @cols = map{s/^\s+|\s+$|\r|\n//g; $_} split( /\t/, $line );
+
+    if( $line =~ m/^(Hugo_Symbol|Chromosome|Tumor_Sample_Barcode)/i ) {
+
+        unless( -e $output_dir ) { mkdir $output_dir or die "ERROR: Couldn't create directory $output_dir! $!"; }
+
+        # Create a T-N pairing TSV file, since it's lost in translation to multi-sample VCF
+        my $tsv_file = "$output_dir/" . substr( $input_maf, rindex( $input_maf, '/' ) + 1 );
+        $tsv_file =~ s/(\.)?(maf|tsv|txt)?$/.pairs.tsv/;
+        my $tsv_fh = IO::File->new( $tsv_file, ">" ) or die "ERROR: Failed to create file $tsv_file\n";
+        $tsv_fh->print( "#Tumor_Sample_Barcode\tMatched_Norm_Sample_Barcode\n" );
+
+        # For each TN-pair in the MAF, initialize a blank VCF with proper VCF headers in output directory
+        my $idx = 0;
+        foreach my $pair ( @tn_pair ) {
+            my ( $t_id, $n_id ) = split( /\t/, $pair );
+            $n_id = "NORMAL" unless( defined $n_id ); # Use a placeholder name for normal if its undefined
+            if( $per_tn_vcfs ) {
+                my $vcf_file = "$output_dir/$t_id\_vs_$n_id.vcf";
+                $tn_vcf{$vcf_file} .= "##fileformat=VCFv4.2\n";
+                $tn_vcf{$vcf_file} .= $ref_header;
+                $tn_vcf{$vcf_file} .= "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n";
+                $tn_vcf{$vcf_file} .= "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic depths of REF and ALT(s) in the order listed\">\n";
+                $tn_vcf{$vcf_file} .= "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Total read depth across this site\">\n";
+                $tn_vcf{$vcf_file} .= "##FILTER=<ID=$_,Description=\"\">\n" foreach ( sort keys %filter_tags );
+                $tn_vcf{$vcf_file} .= "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t$t_id\t$n_id\n";
+            }
+
+            # Set genotype column indexes for the multi-sample VCF, and keep the pairing info
+            $vcf_col_idx{ $t_id } = $idx++ if ( !exists $vcf_col_idx{ $t_id } );
+            $vcf_col_idx{ $n_id } = $idx++ if ( !exists $vcf_col_idx{ $n_id } );
+            $tsv_fh->print( "$t_id\t$n_id\n" );
+        }
+        $tsv_fh->close;
+        next;
+    }
+
+    # For each variant in the MAF, parse out data that can go into the output VCF
+    my ( $chr, $pos, $ref, $al1, $al2, $t_id, $n_id, $n_al1, $n_al2, $id, $qual, $filter ) = map{ my $c = lc; ( defined $col_idx{$c} ? $cols[$col_idx{$c}] : "" )} qw( Chromosome Start_Position Reference_Allele Tumor_Seq_Allele1 Tumor_Seq_Allele2 Tumor_Sample_Barcode Matched_Norm_Sample_Barcode Match_Norm_Seq_Allele1 Match_Norm_Seq_Allele2 variant_id variant_qual FILTER );
+    ++$line_count;
+
+    # Handle a situation in Oncotator MAFs where alleles of DNPs are pipe "|" delimited:
+    ( $ref, $al1, $al2, $n_al1, $n_al2 ) = map{s/\|//g; $_} ( $ref, $al1, $al2, $n_al1, $n_al2 );
+
+    # Make sure that our minimum required columns contain proper data
+    map{( !m/^\s*$/ ) or die "ERROR: $_ is empty in MAF line $line_count!\n" } qw( Chromosome Start_Position Reference_Allele Tumor_Sample_Barcode );
+    (( $col_idx{tumor_seq_allele1} and $col_idx{tumor_seq_allele1} !~ m/^\s*$/ ) or ( $col_idx{tumor_seq_allele2} and $col_idx{tumor_seq_allele2} !~ m/^\s*$/ )) or die "ERROR: At least one of the Tumor_Seq_Allele columns must be non-empty in MAF line $line_count!\n";
+
+    # Parse out read counts for ref/var alleles, if available
+    my ( $t_dp, $t_rad, $t_vad, $n_dp, $n_rad, $n_vad ) = map{ my $c = lc; (( defined $col_idx{$c} and defined $cols[$col_idx{$c}] and $cols[$col_idx{$c}] =~ m/^\d+/ ) ? sprintf( "%.0f", $cols[$col_idx{$c}] ) : '.' )} ( $tum_depth_col, $tum_rad_col, $tum_vad_col, $nrm_depth_col, $nrm_rad_col, $nrm_vad_col );
+
+    # Normal sample ID could be undefined for legit reasons, but we need a placeholder name
+    $n_id = "NORMAL" if( !defined $n_id or $n_id eq "" );
+
+    # If VCF ID, QUAL, or FILTER are undefined or empty, set them to "." per proper VCF specs
+    $id = "." if( !defined $id or $id eq "" );
+    $qual = "." if( !defined $qual or $qual eq "" );
+    $filter = "." if( !defined $filter or $filter eq "" );
+
+    # If normal alleles are unset in the MAF (quite common), assume homozygous reference
+    $n_al1 = $ref if( $n_al1 eq "" );
+    $n_al2 = $ref if( $n_al2 eq "" );
+
+    # Make sure we have at least one variant allele. If not, die with an error
+    if( $al1 eq "" and $al2 eq "" ) {
+        die "ERROR: MAF line $line_count has no variant allele specified at $chr:$pos!\n";
+    }
+    # If one of the variant alleles is unset, assume that it's the same as the reference allele
+    $al1 = $ref if( $al1 eq "" );
+    $al2 = $ref if( $al2 eq "" );
+
+    # When variant alleles are a SNP and a "-", warn user of misusing "-" to denote REF
+    if( $al1 ne $ref and $al2 ne $ref and $al1 ne $al2 and ( $al1 eq "-" or $al2 eq "-" ) and
+        length( $al1 ) == 1 and length( $al2 ) == 1 and length( $ref ) == 1 ) {
+        $al1 = $ref if( $al1 eq "-" );
+        $al2 = $ref if( $al2 eq "-" );
+        warn "WARNING: Replacing '-' with reference allele in: $line";
+    }
+
+    # Blank out the dashes (or other weird chars) used with indels
+    ( $ref, $al1, $al2, $n_al1, $n_al2 ) = map{s/^(\?|-|0)+$//; $_} ( $ref, $al1, $al2, $n_al1, $n_al2 );
+
+    # To simplify code coming up below, ensure that $al2 is always non-REF
+    ( $al1, $al2 ) = ( $al2, $al1 ) if( $al2 eq $ref );
+    # Do the same for the normal alleles, though it makes no difference if both are REF
+    ( $n_al1, $n_al2 ) = ( $n_al2, $n_al1 ) if( $n_al2 eq $ref );
+
+    # Except for MAF-format simple insertions, check ref alleles, and skip lines that mismatch
+    my $locus = "$chr:" . ( $pos - 1 ) . "-" . ( $pos + length( $ref ));
+    if( $ref ne "" or !defined $flanking_bps{$locus} ) {
+        my $ref_from_fasta = ( defined $flanking_bps{$locus} ? substr( $flanking_bps{$locus}, 1, -1 ) : "" );
+        if( $ref ne $ref_from_fasta or !defined $flanking_bps{$locus} ) {
+            # Create the file for skipped variants, if it wasn't already
+            unless( $skipped_fh ) {
+                my $skip_file = "$output_dir/" . substr( $input_maf, rindex( $input_maf, '/' ) + 1 );
+                $skip_file =~ s/(\.)?(maf|tsv|txt)?$/.skipped.tsv/;
+                $skipped_fh = IO::File->new( $skip_file, ">" ) or die "ERROR: Failed to create file $skip_file\n";
+                warn "WARNING: Reference allele mismatches found. Storing them here for debugging: $skip_file\n";
+                $skipped_fh->print( $header_line );
+            }
+            $skipped_fh->print( $line );
+            next;
+        }
+    }
+
+    # To represent indels in VCF format, we need the preceding bp in the reference FASTA
+    my ( $ref_len, $al1_len, $al2_len ) = map{ length( $_ ) } ( $ref, $al1, $al2 );
+    if( $ref_len == 0 or $al1_len == 0 or $al2_len == 0 or ( $ref_len ne $al2_len and substr( $ref, 0, 1 ) ne substr( $al2, 0, 1 ))) {
+        my $prefix_bp = substr( $flanking_bps{$locus}, 0, 1 );
+        # For MAF-format simple insertions, $pos is already the locus of the preceding bp
+        $prefix_bp = substr( $flanking_bps{$locus}, 1, 1 ) if( $ref eq "" );
+        # If this is not a MAF-format simple insertion, decrement $pos
+        --$pos unless( $ref eq "" );
+        # Prefix the fetched reference bp to all the alleles
+        ( $ref, $al1, $al2, $n_al1, $n_al2 ) = map{$prefix_bp.$_} ( $ref, $al1, $al2, $n_al1, $n_al2 );
+    }
+
+    # Fill an array with all unique REF/ALT alleles, and set their 0-based indexes like in a VCF
+    # Notice how we ensure that $alleles[0] is REF and $alleles[1] is the major ALT allele in tumor
+    my ( @alleles, %al_idx );
+    my $idx = 0;
+    foreach my $al ( $ref, $al2, $al1, $n_al2, $n_al1 ) {
+        unless( defined $al_idx{$al} ) {
+            push( @alleles, $al );
+            $al_idx{$al} = $idx++;
+        }
+    }
+
+    # Set tumor and normal genotypes (FORMAT tag GT in VCF)
+    my ( $t_gt, $n_gt ) = ( "0/1", "0/0" ); # Set defaults
+    $t_gt = join( "/", $al_idx{$al2}, $al_idx{$al1} ) if( $al_idx{$al1} ne "0" );
+    $n_gt = join( "/", $al_idx{$n_al2}, $al_idx{$n_al1} ) if( $al_idx{$n_al1} ne "0" );
+    $n_gt = join( "/", $al_idx{$n_al1}, $al_idx{$n_al2} ) if( $al_idx{$n_al2} ne "0" );
+
+    # Create the VCF's comma-delimited ALT field that must list all non-REF (variant) alleles
+    my $alt = join( ",", @alleles[1..$#alleles] );
+
+    # If there are >1 variant alleles, assume that depths in $t_vad and $n_vad are for $al2
+    if( scalar( @alleles ) > 2 ) {
+        $t_vad = join( ",", $t_vad, map{"."}@alleles[2..$#alleles] );
+        $n_vad = join( ",", $n_vad, map{"."}@alleles[2..$#alleles] );
+    }
+
+    # Construct genotype fields for FORMAT tags GT:AD:DP
+    my $t_fmt = "$t_gt:$t_rad,$t_vad:$t_dp";
+    my $n_fmt = "$n_gt:$n_rad,$n_vad:$n_dp";
+
+    # Contruct a VCF formatted line and append it to the respective VCF
+    if( $per_tn_vcfs ) {
+        my $vcf_file = "$output_dir/$t_id\_vs_$n_id.vcf";
+        my $vcf_line = join( "\t", $chr, $pos, $id, $ref, $alt, $qual, $filter, ".", "GT:AD:DP", $t_fmt, $n_fmt );
+        $tn_vcf{$vcf_file} .= "$vcf_line\n";
+    }
+
+    # Store VCF formatted data for the multi-sample VCF
+    my $key = join( "\t", $chr, $pos, $ref, $alt );
+    push( @var_key, $key ) unless( exists $var_frmt{ $key } );
+    $var_frmt{ $key }{ $vcf_col_idx{ $t_id }} = $t_fmt;
+    $var_frmt{ $key }{ $vcf_col_idx{ $n_id }} = $n_fmt;
+    # ::NOTE:: Samples shouldn't have different ID, QUAL, or FILTERs for the same loci+alleles
+    $var_fltr{ $key } = $filter;
+    $var_id{ $key } = $id;
+    $var_qual{ $key } = $qual;
+}
+$maf_fh->close;
+$skipped_fh->close if( $skipped_fh );
+
+# Write the cached contents of per-TN VCFs into files
+if( $per_tn_vcfs ) {
+    foreach my $vcf_file ( keys %tn_vcf ) {
+        my $tn_vcf_fh = IO::File->new( $vcf_file, ">" ) or die "ERROR: Failed to create file $vcf_file\n";
+        $tn_vcf_fh->print( $tn_vcf{$vcf_file} );
+        $tn_vcf_fh->close;
+    }
+}
+
+# Initialize header lines for the multi-sample VCF
+my @vcf_cols = sort { $vcf_col_idx{$a} <=> $vcf_col_idx{$b} } keys %vcf_col_idx;
+my $vcf_fh = IO::File->new( $output_vcf, ">" ) or die "ERROR: Fail to create file $output_vcf\n";
+$vcf_fh->print( "##fileformat=VCFv4.2\n" );
+$vcf_fh->print( $ref_header );
+$vcf_fh->print( "##FORMAT=<ID=GT,Number=1,Type=String,Description=\"Genotype\">\n" );
+$vcf_fh->print( "##FORMAT=<ID=AD,Number=R,Type=Integer,Description=\"Allelic Depths of REF and ALT(s) in the order listed\">\n" );
+$vcf_fh->print( "##FORMAT=<ID=DP,Number=1,Type=Integer,Description=\"Read Depth\">\n" );
+$vcf_fh->print( "##FILTER=<ID=$_,Description=\"\">\n" ) foreach ( sort keys %filter_tags );
+$vcf_fh->print( "#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t" . join("\t", @vcf_cols) . "\n" );
+
+# Write each variant into the multi-sample VCF
+foreach my $key ( @var_key ) {
+    my ( $chr, $pos, $ref, $alt ) = split( "\t", $key );
+    $vcf_fh->print( join( "\t", $chr, $pos, $var_id{ $key }, $ref, $alt, $var_qual{ $key }, $var_fltr{ $key }, ".", "GT:AD:DP" ));
+    map{ $vcf_fh->print( "\t" . (( exists $var_frmt{$key}{$_} ) ? $var_frmt{$key}{$_} : './.:.:.' ))}( 0..$#vcf_cols );
+    $vcf_fh->print( "\n" );
+}
+$vcf_fh->close;
+
+# Make sure that we handled a positive non-zero number of lines in the MAF
+( $line_count > 0 ) or die "ERROR: No variant lines in the input MAF!\n";
+
+__DATA__
+
+=head1 NAME
+
+ maf2vcf.pl - Reformat variants in a MAF into a multisample VCF with GT:AD:DP data if available
+
+=head1 SYNOPSIS
+
+ perl maf2vcf.pl --help
+ perl maf2vcf.pl --input-maf test.maf --output-dir vcfs
+
+=head1 OPTIONS
+
+ --input-maf      Path to input file in MAF format
+ --output-dir     Path to output directory where VCFs will be stored, one per TN-pair
+ --output-vcf     Path to output multi-sample VCF containing all TN-pairs [<output-dir>/<input-maf-name>.vcf]
+ --ref-fasta      Path to reference Fasta file [~/.vep/homo_sapiens/91_GRCh37/Homo_sapiens.GRCh37.75.dna.primary_assembly.fa.gz]
+ --per-tn-vcfs    Specify this to generate VCFs per-TN pair, in addition to the multi-sample VCF
+ --tum-depth-col  Name of MAF column for read depth in tumor BAM [t_depth]
+ --tum-rad-col    Name of MAF column for reference allele depth in tumor BAM [t_ref_count]
+ --tum-vad-col    Name of MAF column for variant allele depth in tumor BAM [t_alt_count]
+ --nrm-depth-col  Name of MAF column for read depth in normal BAM [n_depth]
+ --nrm-rad-col    Name of MAF column for reference allele depth in normal BAM [n_ref_count]
+ --nrm-vad-col    Name of MAF column for variant allele depth in normal BAM [n_alt_count]
+ --help           Print a brief help message and quit
+ --man            Print the detailed manual
+
+=head1 DESCRIPTION
+
+This script breaks down variants in a MAF into a multi-sample VCF, in preparation for annotation with VEP. Can also create VCFs per-TN pair.
+
+=head2 Relevant links:
+
+ Homepage: https://github.com/ckandoth/vcf2maf
+ VCF format: http://samtools.github.io/hts-specs/
+ MAF format: https://wiki.nci.nih.gov/x/eJaPAQ
+
+=head1 AUTHORS
+
+ Cyriac Kandoth (ckandoth@gmail.com)
+ Qingguo Wang (josephw10000@gmail.com)
+
+=head1 LICENSE
+
+ Apache-2.0 | Apache License, Version 2.0 | https://www.apache.org/licenses/LICENSE-2.0
+
+=cut

--- a/modules/vcf2maf/1.3/vcf2maf.smk
+++ b/modules/vcf2maf/1.3/vcf2maf.smk
@@ -402,8 +402,6 @@ rule _vcf2maf_reannotate:
         opts = CFG["options"]["maf2maf"],
         build = lambda w: VCF2MAF_VERSION_MAP[w.target_build],
         custom_enst = lambda w: "--custom-enst " + str(config['lcr-modules']["vcf2maf"]["switches"]["custom_enst"][VCF2MAF_GENOME_VERSION[w.target_build]]) if config['lcr-modules']["vcf2maf"]["switches"]["custom_enst"][VCF2MAF_GENOME_VERSION[w.target_build]] != "" else ""
-    #wildcard_constraints:
-    #    target_build = lambda w: "grch37" if "38" in str(get_original_genome(wildcards)[0]) else "hg38"
     conda:
         CFG["conda_envs"]["vcf2maf"]
     threads:

--- a/modules/vcf2maf/1.3/vcf2maf.smk
+++ b/modules/vcf2maf/1.3/vcf2maf.smk
@@ -28,11 +28,11 @@ CFG = op.setup_module(
 # Define rules to be run locally when using a compute cluster
 localrules:
     _vcf2maf_input_vcf,
-    _vcf2maf_input_bam, 
+    _vcf2maf_input_bam,
     _vcf2maf_output_maf,
-    _vcf2maf_gnomad_filter_maf, 
+    _vcf2maf_gnomad_filter_maf,
     _vcf2maf_install_GAMBLR,
-    _vcf2maf_output_original, 
+    _vcf2maf_output_original,
     _vcf2maf_normalize_prefix,
     _vcf2maf_all
 
@@ -50,13 +50,13 @@ VCF2MAF_GENOME_VERSION = {}  # Will be a simple {"GRCh38-SFU": "grch38"} etc.
 VCF2MAF_GENOME_PREFIX = {}  # Will be a simple hash of {"GRCh38-SFU": True} if chr-prefixed
 VCF2MAF_VERSION_MAP = {}
 
-# Interpret the absolute path to this script so it doesn't get interpreted relative to the module snakefile later. 
+# Interpret the absolute path to this script so it doesn't get interpreted relative to the module snakefile later.
 AUGMENT_SSM = os.path.abspath(config["lcr-modules"]["vcf2maf"]["inputs"]["augment_ssm"])
 
 for genome_build, attributes in config['genome_builds'].items():
     try:
         genome_version = attributes["version"]
-    except KeyError as e:  
+    except KeyError as e:
         # This wasn't included in the reference entry for this genome build
         # This should never happen, as the reference workflow checks for this,
         # but ¯\_(ツ)_/¯
@@ -85,15 +85,15 @@ rule _vcf2maf_input_vcf:
         op.absolute_symlink(input.vcf_gz, output.vcf_gz)
         op.absolute_symlink(input.vcf_gz + ".tbi", output.index)
 
-rule _vcf2maf_input_bam: 
-    input: 
-        bam = CFG["inputs"]["sample_bam"], 
+rule _vcf2maf_input_bam:
+    input:
+        bam = CFG["inputs"]["sample_bam"],
         bai = CFG["inputs"]["sample_bai"]
-    output: 
-        bam = CFG["dirs"]["inputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/tumour.bam", 
+    output:
+        bam = CFG["dirs"]["inputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/tumour.bam",
         bai = CFG["dirs"]["inputs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/tumour.bam.bai"
     group: "bam_and_augment"
-    run: 
+    run:
         op.absolute_symlink(input.bam, output.bam)
         op.absolute_symlink(input.bai, output.bai)
 
@@ -105,11 +105,11 @@ rule _vcf2maf_annotate_gnomad:
         vcf = temp(CFG["dirs"]["decompressed"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.annotated.vcf")
     conda:
         CFG["conda_envs"]["bcftools"]
-    resources: 
+    resources:
         **CFG["resources"]["annotate"]
-    threads: 
+    threads:
         CFG["threads"]["annotate"]
-    wildcard_constraints: 
+    wildcard_constraints:
         base_name = CFG["vcf_base_name"]
     group: "vcf_and_annotate"
     shell:
@@ -138,7 +138,7 @@ rule _vcf2maf_run:
         CFG["threads"]["vcf2maf"]
     resources:
         **CFG["resources"]["vcf2maf"]
-    wildcard_constraints: 
+    wildcard_constraints:
         base_name = CFG["vcf_base_name"]
     shell:
         op.as_one_line("""
@@ -177,8 +177,8 @@ rule _vcf2maf_gnomad_filter_maf:
     params:
         opts = CFG["options"]["gnomAD_cutoff"],
         temp_file = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.dropped.maf"
-    wildcard_constraints: 
-        base_name = CFG["vcf_base_name"], 
+    wildcard_constraints:
+        base_name = CFG["vcf_base_name"],
         maf = "maf"
     shell:
         op.as_one_line("""
@@ -191,9 +191,9 @@ rule _vcf2maf_gnomad_filter_maf:
 
 # Obtain the path to the GAMBLR conda environment
 md5hash = hashlib.md5()
-if workflow.conda_prefix: 
+if workflow.conda_prefix:
     conda_prefix = workflow.conda_prefix
-else: 
+else:
     conda_prefix = os.path.abspath(".snakemake/conda")
 
 md5hash.update(conda_prefix.encode())
@@ -205,7 +205,7 @@ GAMBLR = glob.glob(conda_prefix + "/" + h[:8] + "*")[0]
 
 rule _vcf2maf_install_GAMBLR:
     params:
-        branch = ", ref = \"" + CFG['inputs']['gamblr_branch'] + "\"" if CFG['inputs']['gamblr_branch'] != "" else "", 
+        branch = ", ref = \"" + CFG['inputs']['gamblr_branch'] + "\"" if CFG['inputs']['gamblr_branch'] != "" else "",
         config_url = CFG["inputs"]["gamblr_config_url"]
     output:
         installed = directory(GAMBLR + "/lib/R/library/GAMBLR"),
@@ -215,37 +215,37 @@ rule _vcf2maf_install_GAMBLR:
     shell:
         op.as_one_line("""
         wget -qO {output.config} {params.config_url} &&
-        R -q -e 'options(timeout=9999999); devtools::install_github("morinlab/GAMBLR"{params.branch})' 
+        R -q -e 'options(timeout=9999999); devtools::install_github("morinlab/GAMBLR"{params.branch})'
         """)
 
-rule _vcf2maf_deblacklist_maf: 
-    input: 
-        maf = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.raw.maf", 
+rule _vcf2maf_deblacklist_maf:
+    input:
+        maf = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.raw.maf",
         gamblr = ancient(rules._vcf2maf_install_GAMBLR.output.installed)
-    output: 
+    output:
         maf = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.deblacklisted.maf"
-    log: 
+    log:
         CFG["logs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.deblacklist.log"
-    params: 
-        blacklist_build = lambda w: VCF2MAF_GENOME_VERSION[w.genome_build], 
-        blacklist_template = lambda w: config["lcr-modules"]["vcf2maf"]["inputs"]["blacklist_template"], 
-        project_base = CFG["inputs"]["project_base"], 
-        seq_type_blacklist = CFG["options"]["seq_type_blacklist"], 
-        threshold = CFG["options"]["drop_threshold"] 
+    params:
+        blacklist_build = lambda w: VCF2MAF_GENOME_VERSION[w.genome_build],
+        blacklist_template = lambda w: config["lcr-modules"]["vcf2maf"]["inputs"]["blacklist_template"],
+        project_base = CFG["inputs"]["project_base"],
+        seq_type_blacklist = CFG["options"]["seq_type_blacklist"],
+        threshold = CFG["options"]["drop_threshold"]
     conda:
         CFG['conda_envs']['gamblr']
     threads:
         CFG["threads"]["deblacklist"]
     resources:
         **CFG["resources"]["deblacklist"]
-    wildcard_constraints: 
+    wildcard_constraints:
         base_name = CFG["vcf_base_name"]
     script:
         config["lcr-modules"]["vcf2maf"]['inputs']['deblacklisting']
-        
 
 
-def get_add_mafs(wildcards): 
+
+def get_add_mafs(wildcards):
     CFG = config["lcr-modules"]["vcf2maf"]
     # Retreive the patient ID for this tumour
     patient_id = op.filter_samples(CFG["runs"], tumour_sample_id = wildcards.tumour_id).tumour_patient_id.tolist()
@@ -253,75 +253,75 @@ def get_add_mafs(wildcards):
     this_patient = op.filter_samples(CFG["runs"], tumour_patient_id = patient_id, tumour_genome_build = wildcards.genome_build)
     this_patient = this_patient[~(this_patient["tumour_sample_id"].isin([wildcards.tumour_id]) & this_patient["tumour_seq_type"].isin([wildcards.seq_type]))]
     # Subset to one seq type based on config value
-    if not CFG["options"]["across_seq_types"]: 
+    if not CFG["options"]["across_seq_types"]:
         this_patient = op.filter_samples(this_patient, tumour_seq_type = wildcards.seq_type)
     add_mafs = expand(
-        CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.maf", 
-        zip, 
-        genome_build = this_patient["tumour_genome_build"], 
-        seq_type = this_patient["tumour_seq_type"], 
-        tumour_id = this_patient["tumour_sample_id"], 
-        normal_id = this_patient["normal_sample_id"], 
-        pair_status = this_patient["pair_status"], 
+        CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.maf",
+        zip,
+        genome_build = this_patient["tumour_genome_build"],
+        seq_type = this_patient["tumour_seq_type"],
+        tumour_id = this_patient["tumour_sample_id"],
+        normal_id = this_patient["normal_sample_id"],
+        pair_status = this_patient["pair_status"],
         base_name = [CFG["vcf_base_name"]] * len(this_patient.tumour_sample_id),
         allow_missing = True
     )
     return {"add_maf_files": add_mafs}
 
-# Identify the subset of tumours with multiple tumour samples for augmenting 
+# Identify the subset of tumours with multiple tumour samples for augmenting
 
-if CFG["options"]["augment"]: 
-    if not CFG["options"]["across_seq_types"]: 
+if CFG["options"]["augment"]:
+    if not CFG["options"]["across_seq_types"]:
         MULTI_SAMPLES = CFG["runs"]\
             .groupby(["tumour_patient_id", "tumour_seq_type", "tumour_genome_build"])\
             .filter(lambda x: len(x) > 1)\
             .reset_index()
-    else: 
+    else:
         MULTI_SAMPLES = CFG["runs"]\
             .groupby(["tumour_patient_id", "tumour_genome_build"])\
             .filter(lambda x: len(x) > 1)\
             .reset_index()
-else: 
+else:
     MULTI_SAMPLES = op.discard_samples(CFG["runs"], tumour_sample_id = CFG["runs"]["tumour_sample_id"].tolist())
 
-rule _vcf2maf_augment_maf: 
-    input: 
+rule _vcf2maf_augment_maf:
+    input:
         unpack(get_add_mafs),
-        tumour_bam = str(rules._vcf2maf_input_bam.output.bam), 
+        tumour_bam = str(rules._vcf2maf_input_bam.output.bam),
         index_maf = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.maf"
     output:
         augmented_maf = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.augmented_maf"
-    params: 
+    params:
         script = CFG["inputs"]["augment_ssm"]
-    threads: 
+    threads:
         CFG['threads']['augment']
-    conda: 
+    conda:
         CFG['conda_envs']['pysam']
     resources:
         **CFG['resources']['augment']
     group: "bam_and_augment"
-    wildcard_constraints: 
-        base_name = CFG["vcf_base_name"], 
-        filter = "|".join(["raw", "deblacklisted"]), 
+    wildcard_constraints:
+        base_name = CFG["vcf_base_name"],
+        filter = "|".join(["raw", "deblacklisted"]),
         tumour_id = "|".join(MULTI_SAMPLES.tumour_sample_id.tolist())
     script:
         AUGMENT_SSM
 
 
-rule _vcf2maf_output_original: 
-    input: 
+rule _vcf2maf_output_original:
+    input:
         maf = CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}"
-    output: 
+    output:
         maf = CFG["dirs"]["outputs"] + "{filter}/{maf}/{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}.{base_name}.maf"
-    wildcard_constraints: 
-        base_name = CFG["vcf_base_name"], 
-        filter = "|".join(["raw", "deblacklisted"]), 
-        maf = "|".join(["maf", "augmented_maf"]) 
-    run: 
+    wildcard_constraints:
+        base_name = CFG["vcf_base_name"],
+        filter = "|".join(["raw", "deblacklisted"]),
+        maf = "|".join(["maf", "augmented_maf"])
+    run:
         op.relative_symlink(input.maf, output.maf, in_module = True)
 
 
-    
+
 
 def get_original_genome(wildcards):
     # Determine the original (i.e. input) reference genome for this sample
@@ -349,10 +349,10 @@ def crossmap_input(wildcards):
     CFG = config["lcr-modules"]["vcf2maf"]
     original_genome_build = get_original_genome(wildcards)[0]
     return {
-        "maf": 
+        "maf":
             expand(
-                CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}", 
-                **wildcards, 
+                CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}",
+                **wildcards,
                 genome_build = original_genome_build
             ),
         "convert_coord": config['lcr-modules']["vcf2maf"]["inputs"]["convert_coord"],
@@ -387,6 +387,59 @@ rule _vcf2maf_crossmap:
         """)
 
 
+# Re-annotate variants according to the new genome build
+rule _vcf2maf_reannotate:
+    input:
+        maf = str(rules._vcf2maf_crossmap.output.maf),
+        fasta = reference_files("genomes/{target_build}/genome_fasta/genome.fa"),
+        vep_cache = CFG["inputs"]["vep_cache"]
+    output:
+        maf = temp(CFG["dirs"]["crossmap"] + "{seq_type}--{target_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.{filter}_reannotated.{maf}")
+    log:
+        stdout = CFG["logs"]["normalize"] + "{seq_type}--{target_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.{filter}_{maf}_reannotated.stdout.log",
+        stderr = CFG["logs"]["normalize"] + "{seq_type}--{target_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.{filter}_{maf}_reannotated.stderr.log",
+    params:
+        opts = CFG["options"]["maf2maf"],
+        build = lambda w: VCF2MAF_VERSION_MAP[w.target_build],
+        custom_enst = lambda w: "--custom-enst " + str(config['lcr-modules']["vcf2maf"]["switches"]["custom_enst"][VCF2MAF_GENOME_VERSION[w.target_build]]) if config['lcr-modules']["vcf2maf"]["switches"]["custom_enst"][VCF2MAF_GENOME_VERSION[w.target_build]] != "" else ""
+    #wildcard_constraints:
+    #    target_build = lambda w: "grch37" if "38" in str(get_original_genome(wildcards)[0]) else "hg38"
+    conda:
+        CFG["conda_envs"]["vcf2maf"]
+    threads:
+        CFG["threads"]["maf2maf"]
+    resources:
+        **CFG["resources"]["maf2maf"]
+    wildcard_constraints:
+        base_name = CFG["vcf_base_name"]
+    shell:
+        op.as_one_line("""
+        VCF2MAF_SCRIPT_PATH={VCF2MAF_SCRIPT_PATH};
+        PATH=$VCF2MAF_SCRIPT_PATH:$PATH;
+        MAF2MAF_SCRIPT="$VCF2MAF_SCRIPT_PATH/maf2maf.pl";
+        if [[ -e {output.maf} ]]; then rm -f {output.maf}; fi;
+        vepPATH=$(dirname $(which vep))/../share/variant-effect-predictor*;
+        echo "$(which maf2maf.pl)";
+        echo "$(ls $MAF2MAF_SCRIPT)";
+        if [[ -e $(ls $MAF2MAF_SCRIPT) ]]; then
+            echo "using bundled patched script $MAF2MAF_SCRIPT";
+            echo "Running {rule} for {wildcards.tumour_id} on $(hostname) at $(date)" > {log.stderr};
+            perl $MAF2MAF_SCRIPT
+            --input-maf {input.maf}
+            --ref-fasta {input.fasta}
+            --ncbi-build {params.build}
+            --vep-data {input.vep_cache}
+            --vep-path $vepPATH
+            {params.opts}
+            {params.custom_enst} |
+            cut -f 1-99,108-112,124-134 |
+            grep -v "$(date +"%Y-%m-%d")"
+            > {output.maf}
+            2>> {log.stderr};
+        else echo "ERROR: PATH is not set properly, using $(which maf2maf.pl) will result in error during execution. Please ensure $MAF2MAF_SCRIPT exists." > {log.stderr}; exit 1; fi
+        """)
+
+
 def get_normalize_input(wildcards, todo_only = False):
     CFG = config["lcr-modules"]["vcf2maf"]
     new_genome_build  = wildcards.target_build
@@ -397,44 +450,44 @@ def get_normalize_input(wildcards, todo_only = False):
 
     # Do we need to run CrossMap on this? Check the genome version
     if new_genome_build in original_genome_builds:
-        # Source matches. CrossMap not necessary. No maf normalization needed. 
+        # Source matches. CrossMap not necessary. No maf normalization needed.
         maf = expand(
-            CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}", 
-            **wildcards, 
+            CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}",
+            **wildcards,
             genome_build = new_genome_build
         )
         todo = "symlink"
-    elif new_genome_version in original_genome_version: 
-        # Source matches. CrossMap not necessary. 
+    elif new_genome_version in original_genome_version:
+        # Source matches. CrossMap not necessary.
         # Get the list index of the matching item
         index = original_genome_version.index(new_genome_version)
         # Get the input maf file
         maf = expand(
-            CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}", 
-            **wildcards, 
+            CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.gnomad_filtered.{filter}.{maf}",
+            **wildcards,
             genome_build = original_genome_builds[index]
         )
-        # Check if the chr prefix status is the same e.g. for grch37 vs. hs37d5. 
-        # If yes, symlink. If no, normalize. 
-        if VCF2MAF_GENOME_PREFIX[new_genome_build] == VCF2MAF_GENOME_PREFIX[original_genome_builds[index]]: 
+        # Check if the chr prefix status is the same e.g. for grch37 vs. hs37d5.
+        # If yes, symlink. If no, normalize.
+        if VCF2MAF_GENOME_PREFIX[new_genome_build] == VCF2MAF_GENOME_PREFIX[original_genome_builds[index]]:
             todo = "symlink"
         else:
             todo = "normalize"
     else:
         # Source doesn't match. CrossMap and normalization necessary.
-        target_build = "hg38" if new_genome_version == "grch38" else "hg19" 
+        target_build = "hg38" if new_genome_version == "grch38" else "hg19"
         maf = expand(
-            rules._vcf2maf_crossmap.output.maf, 
-            target_build = target_build, 
+            rules._vcf2maf_reannotate.output.maf,
+            target_build = target_build,
             allow_missing = True
         )
         todo = "normalize"
 
-    if todo_only: 
+    if todo_only:
         return todo
-    else: 
+    else:
         return {"maf": maf}
-   
+
 
 def normalize_prefix(wildcards, input_maf, output_maf, dest_chr):
     maf_open = pd.read_csv(input_maf, sep = "\t")
@@ -455,12 +508,12 @@ rule _vcf2maf_normalize_prefix:
         todo = lambda w: get_normalize_input(w, todo_only = True),
         dest_chr = lambda w: VCF2MAF_GENOME_PREFIX[w.target_build]
     wildcard_constraints:
-        target_build = "|".join(CFG["options"]["target_builds"]), 
+        target_build = "|".join(CFG["options"]["target_builds"]),
         base_name = CFG["vcf_base_name"]
     run:
-        if params.todo == "symlink": 
+        if params.todo == "symlink":
             op.relative_symlink(input.maf, output.maf)
-        else: 
+        else:
             maf_open = pd.read_csv(input.maf[0], sep = "\t")
             print("Normalizing " + input.maf[0])
             # To handle CrossMap weirdness, remove all chr-prefixes and add them back later
@@ -470,7 +523,7 @@ rule _vcf2maf_normalize_prefix:
                 maf_open['Chromosome'] = 'chr' + maf_open['Chromosome'].astype(str)
             print("Writing to " + output.maf)
             maf_open.to_csv(output.maf, sep="\t", index=False)
-        
+
 
 rule _vcf2maf_output_maf:
     input:
@@ -478,7 +531,7 @@ rule _vcf2maf_output_maf:
     output:
         maf = CFG["dirs"]["outputs"] + "{filter}/{maf}/{seq_type}--projection/{tumour_id}--{normal_id}--{pair_status}.{base_name}.{target_build}.maf"
     wildcard_constraints:
-        target_build = "|".join(CFG["options"]["target_builds"]), 
+        target_build = "|".join(CFG["options"]["target_builds"]),
         base_name = CFG["vcf_base_name"]
     run:
         op.relative_symlink(input.maf, output.maf, in_module = True)
@@ -490,37 +543,37 @@ rule _vcf2maf_all:
     input:
         expand(
             expand(
-                str(rules._vcf2maf_output_original.output.maf), 
-                zip, 
-                seq_type = CFG["runs"]["tumour_seq_type"], 
-                genome_build = CFG["runs"]["tumour_genome_build"], 
-                tumour_id = CFG["runs"]["tumour_sample_id"], 
-                normal_id = CFG["runs"]["normal_sample_id"], 
-                pair_status = CFG["runs"]["pair_status"], 
+                str(rules._vcf2maf_output_original.output.maf),
+                zip,
+                seq_type = CFG["runs"]["tumour_seq_type"],
+                genome_build = CFG["runs"]["tumour_genome_build"],
+                tumour_id = CFG["runs"]["tumour_sample_id"],
+                normal_id = CFG["runs"]["normal_sample_id"],
+                pair_status = CFG["runs"]["pair_status"],
                 allow_missing = True
             ),
-            maf = "maf", 
-            base_name = CFG["vcf_base_name"], 
-            filter = CFG["options"]["filter"] 
-        ), 
+            maf = "maf",
+            base_name = CFG["vcf_base_name"],
+            filter = CFG["options"]["filter"]
+        ),
         expand(
             expand(
-                str(rules._vcf2maf_output_original.output.maf), 
-                zip, 
-                seq_type = MULTI_SAMPLES["tumour_seq_type"], 
-                genome_build = MULTI_SAMPLES["tumour_genome_build"], 
-                tumour_id = MULTI_SAMPLES["tumour_sample_id"], 
-                normal_id = MULTI_SAMPLES["normal_sample_id"], 
-                pair_status = MULTI_SAMPLES["pair_status"], 
+                str(rules._vcf2maf_output_original.output.maf),
+                zip,
+                seq_type = MULTI_SAMPLES["tumour_seq_type"],
+                genome_build = MULTI_SAMPLES["tumour_genome_build"],
+                tumour_id = MULTI_SAMPLES["tumour_sample_id"],
+                normal_id = MULTI_SAMPLES["normal_sample_id"],
+                pair_status = MULTI_SAMPLES["pair_status"],
                 allow_missing = True
             ),
-            base_name = CFG["vcf_base_name"], 
-            maf = "augmented_maf", 
-            filter = CFG["options"]["filter"] 
-        ), 
+            base_name = CFG["vcf_base_name"],
+            maf = "augmented_maf",
+            filter = CFG["options"]["filter"]
+        ),
         expand(
             expand(
-                str(rules._vcf2maf_output_maf.output.maf), 
+                str(rules._vcf2maf_output_maf.output.maf),
                 zip,
                 seq_type = CFG["runs"]["tumour_seq_type"],
                 tumour_id = CFG["runs"]["tumour_sample_id"],
@@ -529,14 +582,14 @@ rule _vcf2maf_all:
                 base_name = [CFG["vcf_base_name"]] * len(CFG["runs"]["tumour_sample_id"]),
                 allow_missing = True
             ),
-            target_build = CFG["options"]["target_builds"], 
-            base_name = CFG["vcf_base_name"], 
-            maf = "maf", 
-            filter = CFG["options"]["filter"] 
-        ), 
+            target_build = CFG["options"]["target_builds"],
+            base_name = CFG["vcf_base_name"],
+            maf = "maf",
+            filter = CFG["options"]["filter"]
+        ),
         expand(
             expand(
-                str(rules._vcf2maf_output_maf.output.maf), 
+                str(rules._vcf2maf_output_maf.output.maf),
                 zip,
                 seq_type = MULTI_SAMPLES["tumour_seq_type"],
                 tumour_id = MULTI_SAMPLES["tumour_sample_id"],
@@ -545,9 +598,9 @@ rule _vcf2maf_all:
                 base_name = [CFG["vcf_base_name"]] * len(MULTI_SAMPLES["tumour_sample_id"]),
                 allow_missing = True
             ),
-            target_build = CFG["options"]["target_builds"], 
-            base_name = CFG["vcf_base_name"], 
-            maf = "augmented_maf", 
+            target_build = CFG["options"]["target_builds"],
+            base_name = CFG["vcf_base_name"],
+            maf = "augmented_maf",
             filter = CFG["options"]["filter"]
         )
         # Why are there two expand statements? Well we want every iteration of these MAFs for all the target genome builds


### PR DESCRIPTION
This PR introduces new functionality to re-annotate crossmaped mafs in the vcf2maf module. This will ensure the consistency within particular genome build of variant annotation, regardless whether the sample is aligned to this build initially or was crossmaped. I have:
1. Ensured the re-annotation actually works by checking the HIST1H3B gene (ENSG00000274267 vs ENSG00000124693).
2. Ensured the columns from original maf are propagated to the re-annotated version, and their order is the same, which should maintain existing downstream applications for maf file merging.

The current version of the vcf2maf family of scripts is different from what we have in our production conda environment, so I have bundled the compatible versions with the module. The bundled versions include some debugging features too - and also dropped the annoying `#version 2.4` first line of maf files.

Some variants are being lost during the re-annotation due to the differences in nucleotide sequence between grch37 and hg38. More details discussed on Slack [here](https://morinlabsfu.slack.com/archives/C0GF04TCL/p1666293881045829)