### PR TITLE
Fix bug in chr prefix handling

### DIFF
--- a/modules/battenberg/1.1/config/default.yaml
+++ b/modules/battenberg/1.1/config/default.yaml
@@ -21,8 +21,8 @@ lcr-modules:
                 grch37: " "
             liftover_script_path: "{SCRIPTSDIR}/liftover/1.0/liftover.sh"
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
-            prefixed_projections: ["hg19", "hg38"] # List here the base names of chr-prefixed projections
-            non_prefixed_projections: ["grch37", "grch38", "hs37d5"] # List here the base names of non-prefixed projections
+            prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
+            non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
 
         conda_envs:
             battenberg: "{MODSDIR}/envs/battenberg-1.1.yaml"

--- a/modules/battenberg/1.2/config/default.yaml
+++ b/modules/battenberg/1.2/config/default.yaml
@@ -19,8 +19,8 @@ lcr-modules:
         options:
             liftover_script_path: "{SCRIPTSDIR}/liftover/1.0/liftover.sh"
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
-            prefixed_projections: ["hg19", "hg38"] # List here the base names of chr-prefixed projections
-            non_prefixed_projections: ["grch37", "grch38", "hs37d5"] # List here the base names of non-prefixed projections
+            prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
+            non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
 
         output: # specify the naming convention for the output files under 99-outputs/
                 # required wildcards to use are {seq_type}, {tumour_id}, {normal_id}, {pair_status}, {tool}

--- a/modules/cnvkit/1.0/config/default.yaml
+++ b/modules/cnvkit/1.0/config/default.yaml
@@ -66,8 +66,8 @@ lcr-modules:
             # liftOver options to convert between genomic builds
             liftover_script_path: "{SCRIPTSDIR}/liftover/1.0/liftover.sh"
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
-            prefixed_projections: ["hg19", "hg38"] # List here the base names of chr-prefixed projections
-            non_prefixed_projections: ["grch37", "grch38", "hs37d5"] # List here the base names of non-prefixed projections
+            prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
+            non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
 
         output: # specify the naming convention for the output files under 99-outputs/
                 # required wildcards to use are {seq_type}, {tumour_id}, {normal_id}, {pair_status}, {tool}

--- a/modules/controlfreec/1.2/config/default.yaml
+++ b/modules/controlfreec/1.2/config/default.yaml
@@ -69,8 +69,8 @@ lcr-modules:
             # liftOver options to convert between genomic builds
             liftover_script_path: "{SCRIPTSDIR}/liftover/1.0/liftover.sh"
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
-            prefixed_projections: ["hg19", "hg38"] # List here the base names of chr-prefixed projections
-            non_prefixed_projections: ["grch37", "grch38", "hs37d5"] # List here the base names of non-prefixed projections
+            prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
+            non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
 
         output: # specify the naming convention for the output files under 99-outputs/
                 # required wildcards to use are {seq_type}, {tumour_id}, {normal_id}, {pair_status}, {tool}

--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -20,8 +20,8 @@ lcr-modules:
             cnv2igv: "--mode sequenza"
             liftover_script_path: "{SCRIPTSDIR}/liftover/1.0/liftover.sh"
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
-            prefixed_projections: ["hg19", "hg38"] # List here the base names of chr-prefixed projections
-            non_prefixed_projections: ["grch37", "grch38", "hs37d5"] # List here the base names of non-prefixed projections
+            prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
+            non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
 
         conda_envs:
             sequenza-utils: "{MODSDIR}/envs/sequenza-utils-3.0.0.yaml"


### PR DESCRIPTION
This PR is the fix for issue #259 . In further testing, I also found it affects all other cnv modules. Only the genome builds with inconsistent chr prefixing were affected (hg19-clc, hg19-reddy, grch38).