### PR TITLE
Sp exome fix

### DIFF
--- a/modules/sigprofiler/1.0/config/default.yaml
+++ b/modules/sigprofiler/1.0/config/default.yaml
@@ -71,6 +71,7 @@ lcr-modules:
                 --nnls_remove_penalty 0.01
                 --initial_remove_penalty 0.05
                 --refit_denovo_signatures True
+            extract_search_radius: "2"
 
         threads:
             generator: 1

--- a/modules/sigprofiler/1.0/sigprofiler.smk
+++ b/modules/sigprofiler/1.0/sigprofiler.smk
@@ -165,6 +165,7 @@ rule _sigprofiler_run_extract:
         stderr = CFG["logs"]["extract"] + "{seq_type}--{genome_build}/{sample_set}/extract.{type}.stderr.log"
     params:
         opts = CFG["options"]["extract"],
+        rad = CFG["options"].get("extract_search_radius", "2"),
         ref = lambda w: config['lcr-modules']['sigprofiler']["sigpro_genomes"][w.genome_build],
         context_type = '96,DINUC,ID',
         exome = lambda w: {'genome': 'False', 'capture': 'True'}[w.seq_type],
@@ -177,8 +178,8 @@ rule _sigprofiler_run_extract:
         op.as_one_line("""
         python {input.script} {params.opts} {input.mat} {params.outpath} 
         {params.ref} {params.context_type} {params.exome}
-        $(awk 'BEGIN {{OFS=FS=","}} $1 ~ "*" {{S=substr($1,1,length($1)-1); if (S-2<1) {{print 1}} else {{print S-2}}}}' {input.stat})
-        $(awk 'BEGIN {{OFS=FS=","}} $1 ~ "*" {{S=substr($1,1,length($1)-1); print S+2}}' {input.stat})
+        $(awk 'BEGIN {{OFS=FS=","}} $1 ~ "*" {{S=substr($1,1,length($1)-1); if (S-{params.rad}<1) {{print 1}} else {{print S-{params.rad}}}}}' {input.stat})
+        $(awk 'BEGIN {{OFS=FS=","}} $1 ~ "*" {{S=substr($1,1,length($1)-1); print S+{params.rad}}}' {input.stat})
         {threads} > {log.stdout} 2> {log.stderr}
         """)
 

--- a/modules/sigprofiler/1.0/src/python/run_extractor.py
+++ b/modules/sigprofiler/1.0/src/python/run_extractor.py
@@ -7,13 +7,18 @@ os.environ["OPENBLAS_NUM_THREADS"] = "1" # ulimit fix
 def main():
     """ Performs NMF decomposition with provided matrix """
     args = parse_arguments()
+
+    exome.param = False
+    if args.exome == 'True':
+        exome.param = True
+
     sig.sigProfilerExtractor(input_type = 'matrix', \
                              output = args.output, \
                              input_data = args.input_data, \
                              reference_genome = args.ref, \
                              opportunity_genome = args.ref, \
                              context_type = args.context_type, \
-                             exome = args.exome, \
+                             exome = exome.param, \
                              minimum_signatures = args.minimum_signatures, \
                              maximum_signatures = args.maximum_signatures, \
                              nmf_replicates = args.nmf_replicates, \
@@ -45,7 +50,7 @@ def parse_arguments():
     parser.add_argument('output', help = 'Path to output directory.')
     parser.add_argument('ref', help = 'Reference build of matrix.')
     parser.add_argument('context_type', default = '96,DINUC,ID', help = 'A string of mutaion context name/names separated by comma (","). The items in the list defines the mutational contexts to be considered to extract the signatures. The default value is "96,DINUC,ID", where "96" is the SBS96 context, "DINUC" is the DINUCLEOTIDE context and ID is INDEL context.')
-    parser.add_argument('exome', default = False, type = bool, help = 'Defines if the exomes will be extracted. The default value is "%(default)s".')
+    parser.add_argument('exome', default = 'False', help = 'Defines if the exomes will be extracted. The default value is "%(default)s".')
     parser.add_argument('minimum_signatures', default = 1, type = int, help = "The minimum number of signatures to be extracted. The default value is %(default)s.")
     parser.add_argument('maximum_signatures', default = 25, type = int, help = "The maximum number of signatures to be extracted. The default value is %(default)s.")
     parser.add_argument('cpu', default = -1, type = int, help = 'Number of threads to use. Default use all threads.')


### PR DESCRIPTION
Two problems are being solved by this PR:

1.  Exome flag in sigprofiler was erroneously being set to True no matter what seq_type is set to.
2.  Extract step failing with IndexError: list index out of range error
    - This error is only produced in the extract step but not estimate. I reasoned that the smaller rank search range in the extract may be the cause. In the estimate rule, ranks from 1-25 were searched, but in the extract rule, the search range was limited to the optimal signature rank in the estimate step +/- 2. For example, if estimate returned with optimal rank of 15, in the extract step, ranks between 13 to 17 are searched. I've added an option in the config called "extract_search_radius" with default set to 2 to allow the user to configure the range of signatures to search in the extract step.