### PR TITLE
Housekeeping

### DIFF
--- a/demo/capture_Snakefile.smk
+++ b/demo/capture_Snakefile.smk
@@ -30,7 +30,6 @@ subworkflow reference_files:
 
 # Load module-specific configuration
 configfile: "../modules/slms_3/1.0/config/default.yaml"
-configfile: "../modules/picard_qc/1.0/config/default.yaml"
 configfile: "../modules/bam2fastq/1.2/config/default.yaml"
 configfile: "../modules/sequenza/1.4/config/default.yaml"
 configfile: "../modules/bwa_mem/1.1/config/default.yaml"
@@ -56,7 +55,6 @@ config["lcr-modules"]["_shared"]["samples"] = CAPTURE
 
 # Load module-specific snakefiles
 include: "../modules/slms_3/1.0/slms_3.smk"
-include: "../modules/picard_qc/1.0/picard_qc.smk"
 include: "../modules/bam2fastq/1.2/bam2fastq.smk"
 include: "../modules/sequenza/1.4/sequenza.smk"
 include: "../modules/bwa_mem/1.1/bwa_mem.smk"
@@ -72,7 +70,6 @@ include: "../modules/qc/1.0/qc.smk"
 rule all:
     input:
         rules._slms_3_all.input,
-        rules._picard_qc_all.input,
         rules._bam2fastq_all.input,
         rules._sequenza_all.input,
         rules._bwa_mem_all.input,

--- a/demo/capture_config.yaml
+++ b/demo/capture_config.yaml
@@ -12,17 +12,6 @@ lcr-modules:
             sample_bam: "data/{sample_id}.bam"
             sample_bai: "data/{sample_id}.bam.bai"
 
-    picard_qc:
-        inputs:
-            sample_bam: "data/{sample_id}.bam"
-            sample_bai: "data/{sample_id}.bam.bai"
-        switches:
-            capture_intervals:
-                _default: "reference/exomes/grch37/interval/target_regions.nochr_intervals.txt"
-                # if 'capture_kit_id' is a column in samples.tsv and contain more than one kit_id, specify each kit using the values in the column. e.g. and add the corresponding bed file if needed
-                # S07604624: "reference/exomes/grch37/interval/S07604624_intervals.txt"
-                # <grch38_kit>: "reference/exomes/grch38/interval/<grch38_kit>_intervals.txt"
-
     bam2fastq:
         inputs:
             sample_bam: "data/{sample_id}.bam"

--- a/demo/capture_config.yaml
+++ b/demo/capture_config.yaml
@@ -66,3 +66,4 @@ lcr-modules:
     qc:
         inputs:
             sample_bam: "data/{sample_id}.bam"
+            sample_bai: "data/{sample_id}.bam.bai"

--- a/demo/genome_Snakefile.smk
+++ b/demo/genome_Snakefile.smk
@@ -33,7 +33,6 @@ subworkflow reference_files:
 configfile: "../modules/bam2fastq/1.2/config/default.yaml"
 configfile: "../modules/sequenza/1.4/config/default.yaml"
 configfile: "../modules/bwa_mem/1.1/config/default.yaml"
-configfile: "../modules/controlfreec/1.2/config/default.yaml"
 configfile: "../modules/slms_3/1.0/config/default.yaml"
 configfile: "../modules/gridss/1.1/config/default.yaml"
 configfile: "../modules/battenberg/1.2/config/default.yaml"
@@ -61,7 +60,6 @@ config["lcr-modules"]["_shared"]["samples"] = GENOME
 include: "../modules/bam2fastq/1.2/bam2fastq.smk"
 include: "../modules/sequenza/1.4/sequenza.smk"
 include: "../modules/bwa_mem/1.1/bwa_mem.smk"
-include: "../modules/controlfreec/1.2/controlfreec.smk"
 include: "../modules/slms_3/1.0/slms_3.smk"
 include: "../modules/gridss/1.1/gridss.smk"
 include: "../modules/battenberg/1.2/battenberg.smk"
@@ -76,7 +74,6 @@ rule all:
         rules._bam2fastq_all.input,
         rules._sequenza_all.input,
         rules._bwa_mem_all.input,
-        rules._controlfreec_all.input,
         rules._slms_3_all.input,
         rules._gridss_all.input,
         rules._battenberg_all.input,

--- a/demo/genome_Snakefile.smk
+++ b/demo/genome_Snakefile.smk
@@ -30,14 +30,12 @@ subworkflow reference_files:
 
 # Load module-specific configuration
 
-configfile: "../modules/picard_qc/1.0/config/default.yaml"
 configfile: "../modules/bam2fastq/1.2/config/default.yaml"
 configfile: "../modules/sequenza/1.4/config/default.yaml"
 configfile: "../modules/bwa_mem/1.1/config/default.yaml"
 configfile: "../modules/controlfreec/1.2/config/default.yaml"
 configfile: "../modules/slms_3/1.0/config/default.yaml"
 configfile: "../modules/gridss/1.1/config/default.yaml"
-configfile: "../modules/liftover/1.2/config/default.yaml"
 configfile: "../modules/battenberg/1.2/config/default.yaml"
 configfile: "../modules/pathseq/1.0/config/default.yaml"
 configfile: "../modules/utils/2.1/config/default.yaml"
@@ -60,14 +58,12 @@ config["lcr-modules"]["_shared"]["samples"] = GENOME
 
 # Load module-specific snakefiles
 
-include: "../modules/picard_qc/1.0/picard_qc.smk"
 include: "../modules/bam2fastq/1.2/bam2fastq.smk"
 include: "../modules/sequenza/1.4/sequenza.smk"
 include: "../modules/bwa_mem/1.1/bwa_mem.smk"
 include: "../modules/controlfreec/1.2/controlfreec.smk"
 include: "../modules/slms_3/1.0/slms_3.smk"
 include: "../modules/gridss/1.1/gridss.smk"
-include: "../modules/liftover/1.2/liftover.smk"
 include: "../modules/battenberg/1.2/battenberg.smk"
 include: "../modules/pathseq/1.0/pathseq.smk"
 include: "../modules/utils/2.1/utils.smk"
@@ -77,14 +73,12 @@ include: "../modules/qc/1.0/qc.smk"
 
 rule all:
     input:
-        rules._picard_qc_all.input,
         rules._bam2fastq_all.input,
         rules._sequenza_all.input,
         rules._bwa_mem_all.input,
         rules._controlfreec_all.input,
         rules._slms_3_all.input,
         rules._gridss_all.input,
-        rules._liftover_all.input,
         rules._battenberg_all.input,
         rules._pathseq_all.input,
         rules._qc_all.input

--- a/demo/genome_config.yaml
+++ b/demo/genome_config.yaml
@@ -79,3 +79,4 @@ lcr-modules:
     qc:
         inputs:
             sample_bam: "data/{sample_id}.bam"
+            sample_bai: "data/{sample_id}.bam.bai"

--- a/demo/genome_config.yaml
+++ b/demo/genome_config.yaml
@@ -7,17 +7,6 @@ lcr-modules:
         unmatched_normal_ids:
             genome--grch37: "TCRBOA7-N-WGS"
 
-    picard_qc:
-        inputs:
-            sample_bam: "data/{sample_id}.bam"
-            sample_bai: "data/{sample_id}.bam.bai"
-        switches:
-            capture_intervals:
-                _default: "reference/exomes/grch37/interval/target_regions.nochr_intervals.txt"
-                # if 'capture_kit_id' is a column in samples.tsv and contain more than one kit_id, specify each kit using the values in the column. e.g. and add the corresponding bed file if needed
-                # S07604624: "reference/exomes/grch37/interval/S07604624_intervals.txt"
-                # <grch38_kit>: "reference/exomes/grch38/interval/<grch38_kit>_intervals.txt"
-
     bam2fastq:
         inputs:
             sample_bam: "data/{sample_id}.bam"
@@ -62,13 +51,6 @@ lcr-modules:
             sample_fastq_2: "results/bam2fastq-1.2/01-fastq/{seq_type}/{sample_id}.read2.fastq.gz"
             # Path to the directory where MIXCR should be installed
             mixcr_exec: "data"
-
-    liftover:
-        tool: "sequenza"
-        dirs:
-            _parent: "results/sequenza-1.4_liftover-1.2"
-        inputs:
-            sample_seg: "results/sequenza-1.4/99-outputs/filtered_seg/{seq_type}--{genome_build}/{tumour_sample_id}--{normal_sample_id}--matched.igv.seg"
 
     battenberg:
         inputs:

--- a/demo/genome_config.yaml
+++ b/demo/genome_config.yaml
@@ -29,12 +29,6 @@ lcr-modules:
             sample_fastq_2: "results/bam2fastq-1.2/01-fastq/{seq_type}/{sample_id}.read2.fastq.gz"
         scratch_subdirectories: []
 
-    controlfreec:
-        inputs:
-            sample_bam: "data/{sample_id}.bam"
-            sample_bai: "data/{sample_id}.bam.bai"
-        scratch_subdirectories: [] # mpileup should be in scratch space
-
     slms_3:
         inputs:
             sample_bam: "data/{sample_id}.bam"

--- a/modules/lymphgen/2.0/src/curate_svs_for_lymphgen.R
+++ b/modules/lymphgen/2.0/src/curate_svs_for_lymphgen.R
@@ -26,7 +26,7 @@ if (!(str_detect(sv, "svar_master"))) { # manta
     as.data.frame()
 }
 
-all_fish <- fread(all_fish) %>% as.data.frame()
+all_fish <- read_tsv(all_fish) %>% as.data.frame()
 one_fish <- all_fish %>%
   filter(sample_id == snakemake@wildcards[["tumour_id"]])
 

--- a/modules/qc/1.0/config/default.yaml
+++ b/modules/qc/1.0/config/default.yaml
@@ -11,6 +11,7 @@ lcr-modules:
 
         options:
             samtools_stat: "" # can specify --remove-dups --remove-overlaps
+            samtools_coverage: "" # can specify a particular region of interest
             QualityScoreDistribution: "--VALIDATION_STRINGENCY LENIENT" # can specify --ALIGNED_READS_ONLY true
             CollectWgsMetrics: "--USE_FAST_ALGORITHM true --VALIDATION_STRINGENCY LENIENT"
             CollectHsMetrics: "--VALIDATION_STRINGENCY LENIENT"
@@ -24,12 +25,14 @@ lcr-modules:
                 _default: "https://www.bcgsc.ca/downloads/morinlab/reference/agilent_sureselect_v5_target_regions.hg38.bed"
 
         conda_envs:
-            samtools: "{MODSDIR}/envs/samtools-1.9.yaml"
+            samtools: "{MODSDIR}/envs/samtools-1.9.yaml" # This version is used because for some crams the version 10 has htslib issues on some CentOS servers
+            samtools_cov: "{MODSDIR}/envs/samtools-1.10.yaml" # This is needed because the coverage was introduced only in the version 10
             bedtools: "{MODSDIR}/envs/bedtools-2.29.2.yaml"
             gatkR: "{MODSDIR}/envs/gatkR.yaml"
 
         threads:
             samtools_stat: 8
+            samtools_coverage: 8
             QualityScoreDistribution: 12
             CollectMetrics: 24
             collect: 2
@@ -39,6 +42,9 @@ lcr-modules:
             samtools_stat:
                 mem_mb: 20000
                 samtools_stat: 1
+            samtools_coverage:
+                mem_mb: 20000
+                samtools_coverage: 1
             QualityScoreDistribution:
                 mem_mb: 100000
                 base_qual: 1
@@ -47,6 +53,7 @@ lcr-modules:
                 collect_metrics: 1
             collect:
                 mem_mb: 4000
+                summary: 1
 
         pairing_config:
             genome:

--- a/modules/qc/1.0/config/default.yaml
+++ b/modules/qc/1.0/config/default.yaml
@@ -11,7 +11,7 @@ lcr-modules:
 
         options:
             samtools_stat: "" # can specify --remove-dups --remove-overlaps
-            samtools_coverage: "" # can specify a particular region of interest
+            samtools_coverage: "" # with the flag -r can specify a particular region of interest in the format chr:start-end, for example -r chr1:1M-12M. Otherwise, coverage is calculated for all contigs in bam header (default).
             QualityScoreDistribution: "--VALIDATION_STRINGENCY LENIENT" # can specify --ALIGNED_READS_ONLY true
             CollectWgsMetrics: "--USE_FAST_ALGORITHM true --VALIDATION_STRINGENCY LENIENT"
             CollectHsMetrics: "--VALIDATION_STRINGENCY LENIENT"

--- a/modules/qc/1.0/envs/samtools-1.10.yaml
+++ b/modules/qc/1.0/envs/samtools-1.10.yaml
@@ -1,0 +1,1 @@
+../../../../envs/samtools/samtools-1.10.yaml

--- a/modules/qc/1.0/src/R/aggregate_metrics.R
+++ b/modules/qc/1.0/src/R/aggregate_metrics.R
@@ -110,8 +110,12 @@ if (snakemake@wildcards$seq_type == "capture"){
       PCT_30X
     ) %>%
     mutate(
-      ProportionTargetsNoCoverage=NA, .after = MEAN_COVERAGE,
-      BAIT_SET = "whole-genome", .before = GENOME_TERRITORY,
+      ProportionTargetsNoCoverage=NA, .after = MEAN_COVERAGE
+    ) %>%
+    mutate(
+      BAIT_SET = "whole-genome", .before = GENOME_TERRITORY
+    ) %>%
+    mutate(
       FOLD_ENRICHMENT = NA, .after = PCT_30X
     )
 }


### PR DESCRIPTION
This PR:
1. Adds a collection of per-chromosome coverage to qc module (needs samtools 1.10 env where this was first introduced, but must keep the samtools 1.09 version for the flagstat because of issues on some CentOS versions)
2. Fixes bug in R script that aggregate qc metrics (mutate does not accept multiple `.before` or `.after` in one call)
3. Fixes bug in R script that prepares SVs for lymphgen (drop `data.table::fread()` call because it can't properly set column type on empty files and replace that with `readr::read_tsv()`)
4. Drops deprecated and unused modules in demo
5. Fix bug in demo configs where `sample_bai` key was missing for qc module 