### PR TITLE
Path sent to liftover has wildcards populated

### DIFF
--- a/modules/svar_master/1.0/svar_master.smk
+++ b/modules/svar_master/1.0/svar_master.smk
@@ -112,7 +112,7 @@ def get_manta_vcf(wildcards):
     if wildcards.pair_status in ["matched", "unmatched"]: 
         vcf_name = "somaticSV"
     elif wildcards.pair_status == "no_normal": 
-        vcf_name_ = "tumorSV"
+        vcf_name = "tumorSV"
     vcf = expand(
         str(rules._manta_output_vcf.output.vcf), vcf_name = vcf_name, allow_missing=True
     )

--- a/modules/svar_master/1.0/svar_master.smk
+++ b/modules/svar_master/1.0/svar_master.smk
@@ -112,7 +112,7 @@ def get_manta_vcf(wildcards):
     if wildcards.pair_status in ["matched", "unmatched"]: 
         vcf_name = "somaticSV"
     elif wildcards.pair_status == "no_normal": 
-        vcf_name = "tumorSV"
+        vcf_name_ = "tumorSV"
     vcf = expand(
         str(rules._manta_output_vcf.output.vcf), vcf_name = vcf_name, allow_missing=True
     )
@@ -211,7 +211,7 @@ rule _svar_master_touch_empty_file:
 
 
 config["lcr-modules"]["liftover"]["dirs"]["_parent"] = CFG_SV["dirs"]["_parent"] + "liftover-" + CFG_SV["module_versions"]["liftover"]
-config["lcr-modules"]["liftover"]["inputs"]["sample_file"] = CFG_SV["dirs"]["annotate_svs"] + "{{seq_type}}--{{genome_build}}/{{tumour_id}}--{{normal_id}}--{{pair_status}}.annotated.bedpe"
+config["lcr-modules"]["liftover"]["inputs"]["sample_file"] = CFG_SV["dirs"]["annotate_svs"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}.annotated.bedpe"
 
 include: "../../liftover/" + CFG_SV["module_versions"]["liftover"] + "/liftover.smk"
 


### PR DESCRIPTION
Error provoking this change:
```
InputFunctionExceptionin line 121 of /projects/rmorin/projects/gambl-repos/gambl-sgillis/src/snakemake/../lcr-modules/modules/svar_master/1.0/svar_master.smk:
Error:
  UnboundLocalError: local variable 'vcf_name' referenced before assignment
Wildcards:
  seq_type={capture}
  genome_build={grch37}
  tumour_id={CAHN0002_tumorB}
  normal_id={14-11247N-Chapuy}
  pair_status={unmatched}
Traceback:
  File "/projects/rmorin/projects/gambl-repos/gambl-sgillis/src/snakemake/../lcr-modules/modules/svar_master/1.0/svar_master.smk", line 117, in get_manta_vcf
```
Which occurs in the input function to `rule _svar_master_input_manta`
```
def get_manta_vcf(wildcards): 
    print("tumour",wildcards.tumour_id)
    print("normal",wildcards.normal_id)
    print("type",type(wildcards.pair_status))
    print("value",wildcards.pair_status)
    if wildcards.pair_status in ["matched", "unmatched"]: 
        vcf_name = "somaticSV"
    elif wildcards.pair_status == "no_normal": 
        vcf_name_ = "tumorSV"
    vcf = expand(
        str(rules._manta_output_vcf.output.vcf), vcf_name = vcf_name, allow_missing=True
    )
    return vcf
```
It was being given wildcards with curly braces due to 
```
config["lcr-modules"]["liftover"]["inputs"]["sample_file"] = CFG_SV["dirs"]["annotate_svs"] + "{{seq_type}}--{{genome_build}}/{{tumour_id}}--{{normal_id}}--{{pair_status}}.annotated.bedpe"
```