### PR TITLE
Patch: Changed functions in cnvkit and controlfreec to remove reliance on re…

### DIFF
--- a/modules/cnvkit/1.0/cnvkit.smk
+++ b/modules/cnvkit/1.0/cnvkit.smk
@@ -291,10 +291,15 @@ rule _cnvkit_dbsnp_to_bed:
 
 #### set-up mpileups for BAF calling ####
 def _cnvkit_get_chr_mpileups(wildcards):
+    chrs = []
+    for i in range(1, 23):
+        chrs.append(str(i))
+    chrs.extend(["X", "Y"])
+    if str(wildcards.genome_build).startswith("hg"):
+        chrs = ["chr" + x for x in chrs]
+
     CFG = config["lcr-modules"]["cnvkit"]
-    chrs = reference_files("genomes/" + wildcards.genome_build + "/genome_fasta/main_chromosomes_withY.txt")
-    with open(chrs) as file:
-        chrs = file.read().rstrip("\n").split("\n")
+
     mpileups = expand(
         CFG["dirs"]["SNPs"] + "{{seq_type}}--{{genome_build}}/{{capture_space}}/{{sample_id}}.{chrom}.vcf.gz", 
         chrom = chrs
@@ -302,10 +307,15 @@ def _cnvkit_get_chr_mpileups(wildcards):
     return(mpileups)
     
 def _cnvkit_get_chr_mpileups_tbi(wildcards):
+    chrs = []
+    for i in range(1, 23):
+        chrs.append(str(i))
+    chrs.extend(["X", "Y"])
+    if str(wildcards.genome_build).startswith("hg"):
+        chrs = ["chr" + x for x in chrs]
+
     CFG = config["lcr-modules"]["cnvkit"]
-    chrs = reference_files("genomes/" + wildcards.genome_build + "/genome_fasta/main_chromosomes_withY.txt")
-    with open(chrs) as file:
-        chrs = file.read().rstrip("\n").split("\n")
+
     mpileups = expand(
         CFG["dirs"]["SNPs"] + "{{seq_type}}--{{genome_build}}/{{capture_space}}/{{sample_id}}.{chrom}.vcf.gz.tbi", 
         chrom = chrs

--- a/modules/controlfreec/1.2/controlfreec.smk
+++ b/modules/controlfreec/1.2/controlfreec.smk
@@ -186,14 +186,18 @@ if CFG["options"]["hard_masked"] == True:
 
 def _controlfreec_get_chr_fastas(wildcards):
     CFG = config["lcr-modules"]["controlfreec"]
-    chrs = reference_files("genomes/" + wildcards.genome_build + "/genome_fasta/main_chromosomes_withY.txt")
-    with open(chrs) as file:
-        chromosome = file.read().rstrip("\n").split("\n")
+    chrs = []
+    for i in range(1, 23):
+        chrs.append(str(i))
+    chrs.extend(["X", "Y"])
+    if str(wildcards.genome_build).startswith("hg"):
+        chrs = ["chr" + x for x in chrs]
     fastas = expand(
         CFG["dirs"]["inputs"] +  "references/{{genome_build}}/freec/chr/{chromosome}.fa",
-        chromosome = chromosome
+        chromosome = chrs
     )
     return(fastas)
+
 
 
 #generates file with chromomsome lengths from genome.fa.fai
@@ -258,15 +262,21 @@ rule _controlfreec_input_bam:
 
 #### set-up mpileups for BAF calling ####
 def _controlfreec_get_chr_mpileups(wildcards):
+    chrs = []
+    for i in range(1, 23):
+        chrs.append(str(i))
+    chrs.extend(["X", "Y"])
+    if str(wildcards.genome_build).startswith("hg"):
+        chrs = ["chr" + x for x in chrs]
+
     CFG = config["lcr-modules"]["controlfreec"]
-    chrs = reference_files("genomes/" + wildcards.genome_build + "/genome_fasta/main_chromosomes_withY.txt")
-    with open(chrs) as file:
-        chrs = file.read().rstrip("\n").split("\n")
+
     mpileups = expand(
         CFG["dirs"]["mpileup"] + "{{seq_type}}--{{genome_build}}/{{sample_id}}.{chrom}.minipileup.pileup.gz",
         chrom = chrs
     )
     return(mpileups)
+
 
 
 rule _controlfreec_mpileup_per_chrom:


### PR DESCRIPTION
Patched controlfreec and cnvkit modules together - removed reliance on reference_files() in get functions for generating mpileups in both. In controlfreec, also updated the get function for getting fasta which follows a similar logic.