### PR TITLE
Wrap vcf2maf vep_cache in ancient

### DIFF
--- a/modules/vcf2maf/1.3/vcf2maf.smk
+++ b/modules/vcf2maf/1.3/vcf2maf.smk
@@ -121,7 +121,7 @@ rule _vcf2maf_run:
     input:
         vcf = str(rules._vcf2maf_annotate_gnomad.output.vcf),
         fasta = reference_files("genomes/{genome_build}/genome_fasta/genome.fa"),
-        vep_cache = CFG["inputs"]["vep_cache"]
+        vep_cache = ancient(CFG["inputs"]["vep_cache"])
     output:
         maf = temp(CFG["dirs"]["vcf2maf"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.maf"),
         vep = temp(CFG["dirs"]["decompressed"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.annotated.vep.vcf")
@@ -395,7 +395,7 @@ rule _vcf2maf_reannotate:
     input:
         maf = str(rules._vcf2maf_crossmap.output.maf),
         fasta = reference_files("genomes/{target_build}/genome_fasta/genome.fa"),
-        vep_cache = CFG["inputs"]["vep_cache"]
+        vep_cache = ancient(CFG["inputs"]["vep_cache"])
     output:
         maf = temp(CFG["dirs"]["crossmap"] + "{seq_type}--{target_build}/{tumour_id}--{normal_id}--{pair_status}/{base_name}.{filter}_reannotated.{maf}")
     log:


### PR DESCRIPTION
This addresses a problem with reruns triggered by updated input files that occur when the directory containing the vep_cache, which is difficult to back-date, gets updated. 