### PR TITLE
Small patch for better cram compatibility

### DIFF
--- a/modules/sage/1.1/sage.smk
+++ b/modules/sage/1.1/sage.smk
@@ -67,7 +67,10 @@ rule _sage_input_bam:
         bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai"
     run:
         op.absolute_symlink(input.bam, output.bam)
-        op.absolute_symlink(input.bam+ ".bai", output.bai)
+        if os.path.exists(input.bam+ ".bai"): 
+            op.absolute_symlink(input.bam+ ".bai", output.bai)
+        else: 
+            op.absolute_symlink(input.bam+ ".crai", output.bai)
 
 
 # Setup shared reference files. Symlinking these files to 00-inputs to ensure index and dictionary are present


### PR DESCRIPTION
The Sage module was written to assume that the input alignment had a ".bam" and ".bam.bai" extension - which obviously doesn't hold if you have cram files as input. Rather than updating the input to include another `CFG["inputs"]["bai"]`, which would require updates to existing run scripts that use  Sage, I included a conditional "check if the .bai exists." 