### PR TITLE
Updates to bwa and utils modules

### DIFF
--- a/modules/bam2fastq/1.2/config/default.yaml
+++ b/modules/bam2fastq/1.2/config/default.yaml
@@ -1,5 +1,5 @@
 lcr-modules:
-    
+
     bam2fastq:
 
         inputs:
@@ -12,17 +12,17 @@ lcr-modules:
 
         conda_envs:
             picard: "{MODSDIR}/envs/picard-2.22.3.yaml"
-            
+
         threads:
             bam2fastq: 4
 
         resources:
-            bam2fastq: 
+            bam2fastq:
                 mem_mb: 100000
                 bam: 1
 
-        group: 
-            bam2fastq: "bam2fastq" # For efficient space management, change to match group parameter for downstream tools. 
+        group:
+            bam2fastq: "bam2fastq" # For efficient space management, change to match group parameter for downstream tools.
 
         pairing_config:
             genome:

--- a/modules/bwa_mem/1.1/bwa_mem.smk
+++ b/modules/bwa_mem/1.1/bwa_mem.smk
@@ -34,7 +34,7 @@ if version.parse(current_version) < version.parse(min_oncopipe_version):
                 )
     sys.exit("Instructions for updating to the current version of oncopipe are available at https://lcr-modules.readthedocs.io/en/latest/ (use option 2)")
 
-# End of dependency checking section 
+# End of dependency checking section
 
 # Setup module and store module-specific configuration in `CFG`
 # `CFG` is a shortcut to `config["lcr-modules"]["bwa_mem"]`
@@ -91,14 +91,14 @@ rule _bwa_mem_run:
         CFG["threads"]["bwa_mem"]
     resources:
         **CFG["resources"]["bwa_mem"]
-    wildcard_constraints: 
+    wildcard_constraints:
         sample_id = "|".join(sample_ids_bwa_mem)
     shell:
         op.as_one_line("""
-        bwa mem -t {threads} 
+        bwa mem -t {threads}
         {params.opts}
         {input.fasta}
-        {input.fastq_1} {input.fastq_2} 
+        {input.fastq_1} {input.fastq_2}
         > {output.sam}
         2> {log.stderr}
         """)
@@ -108,7 +108,7 @@ rule _bwa_mem_samtools:
     input:
         sam = str(rules._bwa_mem_run.output.sam)
     output:
-        bam = CFG["dirs"]["bwa_mem"] + "{seq_type}--{genome_build}/{sample_id}_out.bam", 
+        bam = CFG["dirs"]["bwa_mem"] + "{seq_type}--{genome_build}/{sample_id}_out.bam",
         complete = touch(CFG["dirs"]["bwa_mem"] + "{seq_type}--{genome_build}/{sample_id}_out.bam.complete")
     log:
         stderr = CFG["logs"]["bwa_mem"] + "{seq_type}--{genome_build}/{sample_id}/samtools.stderr.log"
@@ -120,12 +120,12 @@ rule _bwa_mem_samtools:
         CFG["threads"]["samtools"]
     resources:
         **CFG["resources"]["samtools"]
-    wildcard_constraints: 
+    wildcard_constraints:
         sample_id = "|".join(sample_ids_bwa_mem)
     shell:
         op.as_one_line("""
         samtools view {params.opts}
-        {input.sam} > {output.bam} 
+        {input.sam} > {output.bam}
         2> {log.stderr}
         """)
 
@@ -135,7 +135,7 @@ rule _bwa_mem_symlink_bam:
         bam = str(rules._bwa_mem_samtools.output.bam)
     output:
         bam = CFG["dirs"]["sort_bam"] + "{seq_type}--{genome_build}/{sample_id}.bam"
-    wildcard_constraints: 
+    wildcard_constraints:
         sample_id = "|".join(sample_ids_bwa_mem)
     run:
         op.absolute_symlink(input.bam, output.bam)
@@ -147,7 +147,7 @@ rule _bwa_mem_symlink_sorted_bam:
         bwa_mem_bam = str(rules._bwa_mem_samtools.output.bam)
     output:
         bam = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}.sort.bam"
-    wildcard_constraints: 
+    wildcard_constraints:
         sample_id = "|".join(sample_ids_bwa_mem)
     run:
         op.absolute_symlink(input.bam, output.bam)
@@ -156,20 +156,67 @@ rule _bwa_mem_symlink_sorted_bam:
 
 
 # Symlinks the final output files into the module results directory (under '99-outputs/')
-rule _bwa_mem_output_bam:
-    input:
-        bam = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".bam",
-        bai = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".bam.bai",
-        sorted_bam = str(rules._bwa_mem_symlink_sorted_bam.input.bam)
-    output:
-        bam = CFG["dirs"]["outputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam"
-    wildcard_constraints: 
-        sample_id = "|".join(sample_ids_bwa_mem)
-    run:
-        op.relative_symlink(input.bam, output.bam, in_module=True)
-        op.relative_symlink(input.bai, output.bam + ".bai", in_module=True)
-        os.remove(input.sorted_bam)
-        shell("touch {input.sorted_bam}.deleted")
+if CFG["compress_to_cram"]:
+
+    rule _bwa_mem_compress_bam:
+        input:
+            bam = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".bam",
+            bai = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".bam.bai",
+            fasta = reference_files("genomes/{genome_build}/genome_fasta/genome.fa")
+        output:
+            cram = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".cram",
+            crai = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".cram.bai"
+        params:
+            opts = CFG["options"]["samtools"]
+        conda:
+            CFG["conda_envs"]["samtools"]
+        threads:
+            CFG["threads"]["samtools"]
+        resources:
+            **CFG["resources"]["samtools"]
+        wildcard_constraints:
+            sample_id = "|".join(sample_ids_bwa_mem)
+        shell:
+            op.as_one_line("""
+            samtools view -C -T {input.fasta} -@ {threads} -o {output.cram} {input.bam}
+                &&
+            samtools index {output.cram} -@ {threads} {output.crai}
+                &&
+            rm {input.bam}
+                &&
+            rm {input.bai}
+            """)
+
+    rule _bwa_mem_output_bam:
+        input:
+            cram = str(rules._bwa_mem_compress_bam.output.cram),
+            crai = str(rules._bwa_mem_compress_bam.output.crai)
+        output:
+            bam = CFG["dirs"]["outputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.cram"
+        wildcard_constraints:
+            sample_id = "|".join(sample_ids_bwa_mem)
+        run:
+            op.relative_symlink(input.cram, output.bam, in_module=True)
+            op.relative_symlink(input.crai, output.bam + ".crai", in_module=True)
+elif not CFG["compress_to_cram"]:
+    rule _bwa_mem_output_bam:
+        input:
+            bam = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".bam",
+            bai = CFG["dirs"]["mark_dups"] + "{seq_type}--{genome_build}/{sample_id}" + CFG["options"]["suffix"] + ".bam.bai",
+            sorted_bam = str(rules._bwa_mem_symlink_sorted_bam.input.bam)
+        output:
+            bam = CFG["dirs"]["outputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam"
+        wildcard_constraints:
+            sample_id = "|".join(sample_ids_bwa_mem)
+        run:
+            op.relative_symlink(input.bam, output.bam, in_module=True)
+            op.relative_symlink(input.bai, output.bam + ".bai", in_module=True)
+            os.remove(input.sorted_bam)
+            shell("touch {input.sorted_bam}.deleted")
+
+else:
+    raise ValueError("CFG['temp_outputs'] must be set to a boolean value (True or False)")
+
 
 
 # Generates the target sentinels for each run, which generate the symlinks

--- a/modules/bwa_mem/1.1/config/default.yaml
+++ b/modules/bwa_mem/1.1/config/default.yaml
@@ -4,6 +4,7 @@ lcr-modules:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_fastq_1: "__UPDATE__"
             sample_fastq_2: "__UPDATE__"
+        compress_to_cram: True
 
         scratch_subdirectories: []
 
@@ -18,19 +19,19 @@ lcr-modules:
         conda_envs:
             bwa: "{MODSDIR}/envs/bwa-0.7.17.yaml"
             samtools: "{MODSDIR}/envs/samtools-1.9.yaml"
-            
+
         threads:
-            bwa_mem: 4
-            samtools: 1
+            bwa_mem: 24
+            samtools: 8
 
         resources:
-            bwa_mem: 
-                mem_mb: 5000
-            samtools: 
-                mem_mb: 5000
-        
-        group: 
-            bwa_mem: "bwa_mem" # Change to match bam2fastq group param for efficient temp fastq deletion. 
+            bwa_mem:
+                mem_mb: 48000
+            samtools:
+                mem_mb: 48000
+
+        group:
+            bwa_mem: "bwa_mem" # Change to match bam2fastq group param for efficient temp fastq deletion.
 
         pairing_config:
             genome:

--- a/modules/utils/2.1/config/default.yaml
+++ b/modules/utils/2.1/config/default.yaml
@@ -1,10 +1,10 @@
 lcr-modules:
     utils:
         inputs:
-            bed: 
+            bed:
                 # add mor genome_build if running with multiple capture/exome kit
                 grch37: "__UPDATE__"
-                
+
         options:
             bam_sort: ""
             bam_markdups: "--overflow-list-size 600000"
@@ -23,16 +23,16 @@ lcr-modules:
             samtools: "envs/samtools-1.9.yaml"
             sambamba: "envs/sambamba-0.7.1.yaml"
             picard: "envs/picard-2.22.3.yaml"
-            
+
         threads:
-            bam_sort: 12
-            bam_markdups: 12
-            bam_index: 6
+            bam_sort: 24
+            bam_markdups: 24
+            bam_index: 8
             interval: 2
 
         mem_mb:
-            bam_sort: 12000
-            bam_markdups: 8000
-            bam_index: 4000
-            interval: 4000
+            bam_sort: 48000
+            bam_markdups: 48000
+            bam_index: 8000
+            interval: 8000
 

--- a/modules/utils/2.1/config/default.yaml
+++ b/modules/utils/2.1/config/default.yaml
@@ -4,11 +4,13 @@ lcr-modules:
             bed:
                 # add mor genome_build if running with multiple capture/exome kit
                 grch37: "__UPDATE__"
+        compress_to_cram: True
 
         options:
             bam_sort: ""
             bam_markdups: "--overflow-list-size 600000"
             bam_index: "-b"
+            bam_to_cram: ""
 ## Lines commented out with `#!` are required for the module to run
 ## Lines commented out with `#?` can optionally be user-configured
 ## Lines commented out with `##` act as regular comments
@@ -29,10 +31,11 @@ lcr-modules:
             bam_markdups: 24
             bam_index: 8
             interval: 2
+            bam_to_cram: 8
 
         mem_mb:
             bam_sort: 48000
             bam_markdups: 48000
             bam_index: 8000
             interval: 8000
-
+            bam_to_cram: 8000

--- a/modules/vcf2maf/1.3/vcf2maf.smk
+++ b/modules/vcf2maf/1.3/vcf2maf.smk
@@ -202,8 +202,8 @@ md5hash.update(f.read())
 f.close()
 h = md5hash.hexdigest()
 GAMBLR = glob.glob(conda_prefix + "/" + h[:8] + "*")
-for file in GAMBLR: 
-    if os.path.isdir(file): 
+for file in GAMBLR:
+    if os.path.isdir(file):
         GAMBLR = file
 
 rule _vcf2maf_install_GAMBLR:
@@ -425,18 +425,23 @@ rule _vcf2maf_reannotate:
         if [[ -e $(ls $MAF2MAF_SCRIPT) ]]; then
             echo "using bundled patched script $MAF2MAF_SCRIPT";
             echo "Running {rule} for {wildcards.tumour_id} on $(hostname) at $(date)" > {log.stderr};
-            perl $MAF2MAF_SCRIPT
-            --input-maf {input.maf}
-            --ref-fasta {input.fasta}
-            --ncbi-build {params.build}
-            --vep-data {input.vep_cache}
-            --vep-path $vepPATH
-            {params.opts}
-            {params.custom_enst} |
-            cut -f 1-99,108-112,124-134 |
-            grep -v "$(date +"%Y-%m-%d")"
-            > {output.maf}
-            2>> {log.stderr};
+            if [[ $(wc -l < {input.maf}) -gt 1 ]]; then
+                perl $MAF2MAF_SCRIPT
+                --input-maf {input.maf}
+                --ref-fasta {input.fasta}
+                --ncbi-build {params.build}
+                --vep-data {input.vep_cache}
+                --vep-path $vepPATH
+                {params.opts}
+                {params.custom_enst} |
+                cut -f 1-99,108-112,124-134 |
+                grep -v "$(date +"%Y-%m-%d")"
+                > {output.maf}
+                2>> {log.stderr};
+            else
+                echo "The input MAF file has one line and is empty. Touched the output MAF file." >> {log.stderr};
+                head -n 1 {input.maf} > {output.maf};
+            fi
         else echo "ERROR: PATH is not set properly, using $(which maf2maf.pl) will result in error during execution. Please ensure $MAF2MAF_SCRIPT exists." > {log.stderr}; exit 1; fi
         """)
 
@@ -516,14 +521,19 @@ rule _vcf2maf_normalize_prefix:
             op.relative_symlink(input.maf, output.maf)
         else:
             maf_open = pd.read_csv(input.maf[0], sep = "\t")
-            print("Normalizing " + input.maf[0])
-            # To handle CrossMap weirdness, remove all chr-prefixes and add them back later
-            maf_open["Chromosome"] = maf_open["Chromosome"].astype(str).str.replace('chr', '')
-            if params.dest_chr:  # Will evaluate to True if the destination genome is chr-prefixed
-                # Add chr prefix
-                maf_open['Chromosome'] = 'chr' + maf_open['Chromosome'].astype(str)
-            print("Writing to " + output.maf)
-            maf_open.to_csv(output.maf, sep="\t", index=False)
+            # Check whether the input maf is empty
+            if maf_open.empty:
+                print(f"The incoming maf {input.maf[0]} is empty! Will symlink it instead of normalizing")
+                maf_open.to_csv(output.maf, sep="\t", index=False)
+            else:
+                print("Normalizing " + input.maf[0])
+                # To handle CrossMap weirdness, remove all chr-prefixes and add them back later
+                maf_open["Chromosome"] = maf_open["Chromosome"].astype(str).str.replace('chr', '')
+                if params.dest_chr:  # Will evaluate to True if the destination genome is chr-prefixed
+                    # Add chr prefix
+                    maf_open['Chromosome'] = 'chr' + maf_open['Chromosome'].astype(str)
+                print("Writing to " + output.maf)
+                maf_open.to_csv(output.maf, sep="\t", index=False)
 
 
 rule _vcf2maf_output_maf:


### PR DESCRIPTION
The alignment to bam is not used as much anymore and the cram-compression is more often required. This PR adds config to the bwa_mem module which will dictate whether the output should be cram-compressed (default) or not (reverts to legacy behaviour). No version update is needed as the update not significant enough to be not compatible with previous outputs.
In addition, the default resources specified in the config are pretty generous and in turn some even exomes may take veeeeryyyy loooooong time to process. Easy to address in the project config but also made default values more sensible here.
This setup was tested on the gambl data and used in the download of samples from this PR: https://github.com/morinlab/gambl/pull/322


This PR also contains fix for handling of empty files in the vcf2maf reannotation reported in the issue #321 