### PR TITLE
Fishhook fixes and level3 modules metadata dimensions are passed to the prepare script

### DIFF
--- a/envs/fishhook/fishhook.post-deploy.sh
+++ b/envs/fishhook/fishhook.post-deploy.sh
@@ -2,6 +2,6 @@
 set -o pipefail
 set -e # Exit on error
 
-R --vanilla -q -e 'devtools::install_github("mskilab/gUtils", dependencies = FALSE, upgrade = "never")' > /home/sgillis/fishhook_deploy.txt
-R --vanilla -q -e 'devtools::install_github("mskilab/gTrack", dependencies = FALSE, upgrade = "never")' >> /home/sgillis/fishhook_deploy.txt
-R --vanilla -q -e 'devtools::install_github("mskilab/fishHook", dependencies = FALSE, upgrade = "never")' >> /home/sgillis/fishhook_deploy.txt
+R --vanilla -q -e 'devtools::install_github("mskilab/gUtils", dependencies = FALSE, upgrade = "never")'
+R --vanilla -q -e 'devtools::install_github("mskilab/gTrack", dependencies = FALSE, upgrade = "never")'
+R --vanilla -q -e 'devtools::install_github("mskilab/fishHook", dependencies = FALSE, upgrade = "never")'

--- a/envs/fishhook/fishhook.post-deploy.sh
+++ b/envs/fishhook/fishhook.post-deploy.sh
@@ -1,0 +1,7 @@
+#!env bash
+set -o pipefail
+set -e # Exit on error
+
+R --vanilla -q -e 'devtools::install_github("mskilab/gUtils", dependencies = FALSE, upgrade = "never")' > /home/sgillis/fishhook_deploy.txt
+R --vanilla -q -e 'devtools::install_github("mskilab/gTrack", dependencies = FALSE, upgrade = "never")' >> /home/sgillis/fishhook_deploy.txt
+R --vanilla -q -e 'devtools::install_github("mskilab/fishHook", dependencies = FALSE, upgrade = "never")' >> /home/sgillis/fishhook_deploy.txt

--- a/envs/fishhook/fishhook.yaml
+++ b/envs/fishhook/fishhook.yaml
@@ -2,7 +2,7 @@ name: fishhook
 channels:
   - bioconda
   - conda-forge
-  - defaults
+  - r
 dependencies:
   - _libgcc_mutex=0.1=conda_forge
   - _openmp_mutex=4.5=2_gnu
@@ -274,4 +274,3 @@ dependencies:
   - yq=3.2.3=pyhd8ed1ab_0
   - zlib=1.2.13=hd590300_5
   - zstd=1.5.5=hfc55251_0
-prefix: /home/sgillis/miniconda3/envs/fishhook

--- a/modules/dnds/1.2/dnds.smk
+++ b/modules/dnds/1.2/dnds.smk
@@ -101,6 +101,7 @@ checkpoint _dnds_prepare_maf:
         include_non_coding = str(CFG["include_non_coding"]).upper(),
         mode = "dNdS",
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_MAFS

--- a/modules/fishhook/1.2/config/default.yaml
+++ b/modules/fishhook/1.2/config/default.yaml
@@ -5,7 +5,7 @@ lcr-modules:
             # Available wildcards: {seq_type}
             master_maf: "__UPDATE__"
             subsetting_categories: "__UPDATE__" # e.g. "data/metadata/level3_subsetting_categories.tsv"
-        sample_set: ["__UPDATE__"] # E.g. ["DLBCL-only", "BL_DLBCL-BL-like_all"]
+        sample_set: "__UPDATE__"
         # Uncomment the following line to add a launch_date. Otherwise the current year-month will be used
         # launch_date: ""
 
@@ -28,6 +28,7 @@ lcr-modules:
             fishhook: "{MODSDIR}/envs/fishhook.yaml"
 
         threads:
+            prepare_maf: 4
             fishhook: 1
 
         resources:

--- a/modules/fishhook/1.2/config/default.yaml
+++ b/modules/fishhook/1.2/config/default.yaml
@@ -28,7 +28,6 @@ lcr-modules:
             fishhook: "{MODSDIR}/envs/fishhook.yaml"
 
         threads:
-            prepare_maf: 4
             fishhook: 1
 
         resources:

--- a/modules/fishhook/1.2/envs/fishhook.post-deploy.sh
+++ b/modules/fishhook/1.2/envs/fishhook.post-deploy.sh
@@ -1,0 +1,1 @@
+../../../../envs/fishhook/fishhook.post-deploy.sh

--- a/modules/fishhook/1.2/scr/R/run_fishhook.R
+++ b/modules/fishhook/1.2/scr/R/run_fishhook.R
@@ -22,9 +22,9 @@ suppressWarnings(
 )
 
 # Read in maf and convert to GRange
-maf = gr.sub(dt2gr(fread(snakemake@input[[2]])))
+maf = gr.sub(dt2gr(fread(snakemake@input[["maf"]])))
 
-if(!snakemake@params[[1]]){
+if(!snakemake@params[["include_silent"]]){
   message("Excluding Silent Mutations ...")
   events = maf %Q% (Variant_Classification != 'Silent')
 }else{
@@ -32,12 +32,12 @@ if(!snakemake@params[[1]]){
 }
 
 # Use tile mode or gene list mode
-if((snakemake@params[[3]])){
+if((snakemake@params[["target_gene_list"]])){
   message("Running FishHook with Gene List...")
-  message(paste0("Gene List File: ", snakemake@params[[4]]))
-  genes = gr.sub(import(snakemake@params[[4]]))
+  message(paste0("Gene List File: ", snakemake@params[["gene_list"]]))
+  genes = gr.sub(import(snakemake@params[["gene_list"]]))
 
-  if(snakemake@params[[5]]){
+  if(snakemake@params[["target_gene_list_only_protein_coding"]]){
     message("Subsetting Gene List for Protein Coding Gene Only ...")
     genes = genes %Q% (gene_type == 'protein_coding')
   }
@@ -48,7 +48,7 @@ if((snakemake@params[[3]])){
 }else{
   message("Running FishHook with Tiles ...")
   # Split maf to tiles
-  tiles = gr.tile(seqinfo(maf), snakemake@params[[2]])
+  tiles = gr.tile(seqinfo(maf), snakemake@params[["tiles_size"]])
 
   fish = Fish(hypotheses = tiles,
                     events = events,
@@ -57,13 +57,13 @@ if((snakemake@params[[3]])){
 }
 
 # If user provided covariates files
-if(!is.null(snakemake@params[[6]])){
+if(!is.null(snakemake@params[["covariates"]])){
   message("Running FishHook with the Following Covariates...")
-  message(names(snakemake@params[[6]]))
+  message(names(snakemake@params[["covariates"]]))
 
   covariates <- c()
-  for(cov_name in names(snakemake@params[[6]])){
-    cov_data <- gr.sub(import(snakemake@params[[6]][[cov_name]]))
+  for(cov_name in names(snakemake@params[["covariates"]])){
+    cov_data <- gr.sub(import(snakemake@params[["covariates"]][[cov_name]]))
     cov <- Cov(cov_data, name = cov_name)
     covariates <- append(covariates, cov)
   }
@@ -81,7 +81,7 @@ df.result = gr2dt(result)
 
 write.table(
   df.result,
-  file=snakemake@output[[1]],
+  file=snakemake@output[["tsv"]],
   quote=FALSE,
   sep='\t',
   row.names = FALSE)

--- a/modules/gistic2/1.2/gistic2.smk
+++ b/modules/gistic2/1.2/gistic2.smk
@@ -110,6 +110,7 @@ checkpoint _gistic2_prepare_seg:
         CFG["conda_envs"]["prepare"]
     params:
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value=''),
         mode = "gistic2"
     script:

--- a/modules/hotmaps/1.1/hotmaps.smk
+++ b/modules/hotmaps/1.1/hotmaps.smk
@@ -124,6 +124,7 @@ checkpoint _hotmaps_prep_input:
         include_non_coding = str(CFG["maf_processing"]["include_non_coding"]).upper(),
         mode = "HotMAPS",
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_MAFS

--- a/modules/mutsig/1.2/mutsig.smk
+++ b/modules/mutsig/1.2/mutsig.smk
@@ -106,6 +106,7 @@ checkpoint _mutsig_prepare_maf:
         include_non_coding = str(CFG["include_non_coding"]).upper(),
         mode = "MutSig2CV",
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_MAFS

--- a/modules/oncodriveclustl/1.1/oncodriveclustl.smk
+++ b/modules/oncodriveclustl/1.1/oncodriveclustl.smk
@@ -82,6 +82,7 @@ checkpoint _oncodriveclustl_prep_input:
         include_non_coding = str(CFG["maf_processing"]["include_non_coding"]).upper(),
         mode = "OncodriveCLUSTL",
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_MAFS

--- a/modules/oncodrivefml/1.1/oncodrivefml.smk
+++ b/modules/oncodrivefml/1.1/oncodrivefml.smk
@@ -79,6 +79,7 @@ checkpoint _oncodrivefml_prep_input:
         include_non_coding = str(CFG["maf_processing"]["include_non_coding"]).upper(),
         mode = "OncodriveFML",
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_MAFS

--- a/modules/rainstorm/1.2/rainstorm.smk
+++ b/modules/rainstorm/1.2/rainstorm.smk
@@ -124,6 +124,7 @@ checkpoint _rainstorm_prepare_maf:
         include_non_coding = str(CFG["include_non_coding"]).upper(),
         mode = "rainstorm",
         metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_MAFS


### PR DESCRIPTION
See lcr-scripts PR https://github.com/LCR-BCCRC/lcr-scripts/pull/70

This was tested with fishhook, hence the branch name, although all level3 modules have been updated. They should not reuire a version bump since outputs should remain the same.

This PR also includes adding a post-deploy script to install the fishhook R package in the conda env. Other minor issues found and corrected were

 - the "mode" parameter for the prepare step was mispelled
 - the fishhook RScript used numbers to get the inputs/outputs/parameters from the snakemake list object in R, which changed when no longer needing the install rule. So the script now uses the names in the list object