### PR TITLE
add cookiecutter template for level3 modules

### DIFF
--- a/docs/source/for_developers.rst
+++ b/docs/source/for_developers.rst
@@ -47,7 +47,7 @@ Getting Started
       git branch  # Confirm you're on the new branch (with the asterisk)
       git push -u origin "module/<module_name>/1.0"
 
-6. Create a new module based on the :ref:`module-template` or . Check out the :ref:`module-template` section for details on the fields requested during module creation.
+6. Create a new module based on the :ref:`module-template`. Check out the :ref:`module-template` section for details on the fields requested during module creation.
 
    .. code:: bash
 
@@ -110,7 +110,7 @@ When you run the command listed in the :ref:`getting-started-dev` instructions, 
 
    - Each of these should only consist of lowercase alphanumerical characters or underscores (*i.e.* no spaces).
 
-   - **level3-template** will ask for either ``maf`` or ``seg``, as these are the current two files types used for sample set level analyses (see :ref:`what-are-modules` for more details). 
+   - **level3-template** will ask for either ``maf`` or ``seg``, as these are the current two files types used for sample set level analyses (see :ref:`what-are-modules` for more details).
 
 - ``module_run_per``: Possible values are ``tumour`` and ``sample``. This field determines whether the module is intended to be run once per tumour (*e.g.* variant calling modules) or once per sample regardless of tissue status (*e.g.* BAM alignment and processing)
 

--- a/docs/source/for_developers.rst
+++ b/docs/source/for_developers.rst
@@ -47,11 +47,13 @@ Getting Started
       git branch  # Confirm you're on the new branch (with the asterisk)
       git push -u origin "module/<module_name>/1.0"
 
-6. Create a new module based on the :ref:`module-template`. Check out the :ref:`module-template` section for details on the fields requested during module creation.
+6. Create a new module based on the :ref:`module-template` or . Check out the :ref:`module-template` section for details on the fields requested during module creation.
 
    .. code:: bash
 
       cookiecutter "template/" --output-dir 'modules/'
+      # For level3 modules, instead run the below
+      # cookiecutter "template-level3/" --output-dir 'modules/'
       git add modules/<module_name>/1.0/
       git commit -m "Add initial draft of <module_name> version 1.0"
       git push origin "module/<module_name>/1.0"
@@ -108,9 +110,9 @@ When you run the command listed in the :ref:`getting-started-dev` instructions, 
 
    - Each of these should only consist of lowercase alphanumerical characters or underscores (*i.e.* no spaces).
 
-- ``module_run_per``: Possible values are ``tumour`` and ``sample``. This field determines whether the module is intended to be run once per tumour (*e.g.* variant calling modules) or once per sample regardless of tissue status (*e.g.* BAM alignment and processing).
+   - **level3-template** will ask for either ``maf`` or ``seg``, as these are the current two files types used for sample set level analyses (see :ref:`what-are-modules` for more details). 
 
-   Additional options will be added later, such as ``tumour_cohort`` and ``sample_cohort`` for level-3 modules (see :ref:`what-are-modules` for more details).
+- ``module_run_per``: Possible values are ``tumour`` and ``sample``. This field determines whether the module is intended to be run once per tumour (*e.g.* variant calling modules) or once per sample regardless of tissue status (*e.g.* BAM alignment and processing)
 
 -  ``seq_type.genome``, ``seq_type.capture``, and ``seq_type.mrna``: Possible values are ``omit``,``unpaired``, ``matched_only``, ``allow_unmatched``, and ``no_normal``, . These fields determine which sequencing data types (``seq_type``) are intended as input for the module and whether each ``seq_type`` is intended to be run in paired or unpaired mode, and if in paired mode, whether to allow unmatched pairs. Select ``omit`` if a ``seq_type`` is not applicable for the module or ``unpaired`` if you are running the module once per sample. For more information on the last three modes, check out the documentation for the :py:func:`oncopipe.generate_pairs` function.  The fields correspond to whole genome, hybrid capture-based, and RNA sequencing, respectively.
 

--- a/template-level3/cookiecutter.json
+++ b/template-level3/cookiecutter.json
@@ -1,0 +1,7 @@
+{
+  "module_name": null,
+  "module_author": null,
+  "original_author": null,
+  "input_file_type": ["maf", "seg"],
+  "output_file_type": null
+}

--- a/template-level3/hooks/post_gen_project.py
+++ b/template-level3/hooks/post_gen_project.py
@@ -1,0 +1,12 @@
+#!/usr/bin/python3
+
+# Load modules
+import os
+
+# Symlink schema to avoid duplicating files
+os.symlink("../../../../schemas/base/base-1.0.yaml", "1.0/schemas/base-1.0.yaml")
+
+# Delete hidden files serving only to have the directories be visible to Git
+os.remove("1.0/envs/.gitkeep")
+os.remove("1.0/etc/.gitkeep")
+os.remove("1.0/schemas/.gitkeep")

--- a/template-level3/hooks/pre_gen_project.py
+++ b/template-level3/hooks/pre_gen_project.py
@@ -8,7 +8,7 @@ module_name = "{{ cookiecutter.module_name }}"
 module_author = "{{ cookiecutter.module_author }}"
 original_author = "{{ cookiecutter.original_author }}"
 input_file_type = "{{ cookiecutter.input_file_type }}"
-output_file_type = "{{ cookiecutter.input_file_type }}"
+output_file_type = "{{ cookiecutter.output_file_type }}"
 
 # Ensure that module name conforms to requirements
 assert re.fullmatch(r"[a-z0-9_]+", module_name), (

--- a/template-level3/hooks/pre_gen_project.py
+++ b/template-level3/hooks/pre_gen_project.py
@@ -1,0 +1,23 @@
+#!/usr/bin/python3
+
+# Load modules
+import re
+
+# Get cookiecutter variables
+module_name = "{{ cookiecutter.module_name }}"
+module_author = "{{ cookiecutter.module_author }}"
+original_author = "{{ cookiecutter.original_author }}"
+input_file_type = "{{ cookiecutter.input_file_type }}"
+output_file_type = "{{ cookiecutter.input_file_type }}"
+
+# Ensure that module name conforms to requirements
+assert re.fullmatch(r"[a-z0-9_]+", module_name), (
+    f"`module_name` ('{module_name}') should only consist of lowercase "
+    "alphanumerical characters or underscores (_i.e._ no spaces)."
+)
+
+# Ensure that output file type conforms to requirements
+assert re.fullmatch(r"[a-z0-9_]+", output_file_type), (
+    f"`output_file_type` ('{output_file_type}') should only consist of lowercase "
+    "alphanumerical characters or underscores (_i.e._ no spaces)."
+)

--- a/template-level3/{{cookiecutter.module_name}}/1.0/config/default.yaml
+++ b/template-level3/{{cookiecutter.module_name}}/1.0/config/default.yaml
@@ -1,0 +1,44 @@
+lcr-modules:
+    
+    {{cookiecutter.module_name}}:
+
+        inputs:
+           # Available wildcards: {seq_type} {projection}
+            master_{{cookiecutter.input_file_type}}: "__UPDATE__"
+            subsetting_categories: "__UPDATE__" # e.g. "data/metadata/level3_subsetting_categories.tsv"
+        sample_set: "__UPDATE__" # E.g. ["DLBCL-only", "BL_DLBCL-BL-like_all"]
+        projections: ["grch37", "hg38"]
+        # Uncomment the following line to add a launch_date. Otherwise the current year-month will be used
+        # launch_date: "2025-01"
+
+        {%- if cookiecutter.input_file_type == "maf" %}
+        include_non_coding: True
+        {%- endif %}
+
+        prepare_script: "{SCRIPTSDIR}/generate_smg_inputs/1.1/generate_smg_inputs.R"
+
+        scratch_subdirectories: []
+
+        options:
+            {{cookiecutter.module_name}}_run: ""
+
+        conda_envs:
+            prepare: "{REPODIR}/envs/gatk/gatkR.yaml"
+            {{cookiecutter.module_name}}: "{MODSDIR}/envs/{{cookiecutter.module_name}}.yaml"
+            
+        threads:
+            {{cookiecutter.module_name}}_run: 4
+
+        resources:
+            {{cookiecutter.module_name}}_run: 
+                mem_mb: 2000
+            
+        pairing_config:
+            genome:
+                run_paired_tumours: False
+                run_unpaired_tumours_with: "no_normal"
+                run_paired_tumours_as_unpaired: True
+            capture:
+                run_paired_tumours: False
+                run_unpaired_tumours_with: "no_normal"
+                run_paired_tumours_as_unpaired: True

--- a/template-level3/{{cookiecutter.module_name}}/1.0/envs/.gitkeep
+++ b/template-level3/{{cookiecutter.module_name}}/1.0/envs/.gitkeep
@@ -1,0 +1,4 @@
+This file exists just to make the `envs/` directory visible to Git.
+This file will get deleted automatically by cookiecutter after the
+new module is created. If you don't have accessory files to add to
+`envs/`, you can delete the directory. 

--- a/template-level3/{{cookiecutter.module_name}}/1.0/etc/.gitkeep
+++ b/template-level3/{{cookiecutter.module_name}}/1.0/etc/.gitkeep
@@ -1,0 +1,4 @@
+This file exists just to make the `etc/` directory visible to Git.
+This file will get deleted automatically by cookiecutter after the
+new module is created. If you don't have accessory files to add to
+`etc/`, you can delete the directory. 

--- a/template-level3/{{cookiecutter.module_name}}/1.0/schemas/.gitkeep
+++ b/template-level3/{{cookiecutter.module_name}}/1.0/schemas/.gitkeep
@@ -1,0 +1,3 @@
+This file exists just to make the `schemas/` directory visible to Git.
+This file will get deleted automatically by cookiecutter after the
+new module is created. 

--- a/template-level3/{{cookiecutter.module_name}}/1.0/{{cookiecutter.module_name}}.smk
+++ b/template-level3/{{cookiecutter.module_name}}/1.0/{{cookiecutter.module_name}}.smk
@@ -1,0 +1,188 @@
+#!/usr/bin/env snakemake
+
+
+##### ATTRIBUTION #####
+
+
+# Original Author:  {{cookiecutter.original_author}}
+# Module Author:    {{cookiecutter.module_author}}
+# Contributors:     N/A
+
+
+##### SETUP #####
+
+# Import package with useful functions for developing analysis modules
+import sys, os
+from os.path import join
+import glob
+import hashlib
+import oncopipe as op
+from datetime import datetime
+import numpy as np
+
+# Check that the oncopipe dependency is up-to-date. Add all the following lines to any module that uses new features in oncopipe
+min_oncopipe_version="1.0.11"
+import pkg_resources
+try:
+    from packaging import version
+except ModuleNotFoundError:
+    sys.exit("The packaging module dependency is missing. Please install it ('pip install packaging') and ensure you are using the most up-to-date oncopipe version")
+
+# To avoid this we need to add the "packaging" module as a dependency for LCR-modules or oncopipe
+
+current_version = pkg_resources.get_distribution("oncopipe").version
+if version.parse(current_version) < version.parse(min_oncopipe_version):
+    print('\x1b[0;31;40m' + f'ERROR: oncopipe version installed: {current_version}' + '\x1b[0m')
+    print('\x1b[0;31;40m' + f"ERROR: This module requires oncopipe version >= {min_oncopipe_version}. Please update oncopipe in your environment" + '\x1b[0m')
+    sys.exit("Instructions for updating to the current version of oncopipe are available at https://lcr-modules.readthedocs.io/en/latest/ (use option 2)")
+
+# End of dependency checking section
+
+# Setup module and store module-specific configuration in `CFG`
+# `CFG` is a shortcut to `config["lcr-modules"]["{{cookiecutter.module_name}}"]`
+CFG = op.setup_module(
+    name = "{{cookiecutter.module_name}}",
+    version = "1.0",
+    # TODO: If applicable, add more granular output subdirectories
+    subdirectories = ["inputs", "prepare_{{cookiecutter.input_file_type}}", "{{cookiecutter.module_name}}", "outputs"],
+)
+
+# Define rules to be run locally when using a compute cluster
+# TODO: Replace with actual rules once you change the rule names
+localrules:
+    _{{cookiecutter.module_name}}_input_{{cookiecutter.input_file_type}},
+    _{{cookiecutter.module_name}}_input_subsetting_categories,
+    _{{cookiecutter.module_name}}_prepare_{{cookiecutter.input_file_type}},
+    _{{cookiecutter.module_name}}_output_{{cookiecutter.output_file_type}},
+    _{{cookiecutter.module_name}}_all,
+
+
+##### RULES #####
+if "launch_date" in CFG:
+    launch_date = CFG['launch_date']
+else:
+    launch_date = datetime.today().strftime('%Y-%m')
+
+# Interpret the absolute path to the prepare script so it doesn't get interpreted relative to the module snakefile later.
+PREPARE_SCRIPT =  os.path.abspath(config["lcr-modules"]["{{cookiecutter.module_name}}"]["prepare_script"])
+
+# Symlinks the input files into the module results directory (under '00-inputs/')
+rule _{{cookiecutter.module_name}}_input_{{cookiecutter.input_file_type}}:
+    input:
+        {{cookiecutter.input_file_type}} = CFG["inputs"]["master_{{cookiecutter.input_file_type}}"]
+    output:
+        {{cookiecutter.input_file_type}} = CFG["dirs"]["inputs"] + "{{cookiecutter.input_file_type}}/{seq_type}/{sample_set}--{projection}--{launch_date}/input.{{cookiecutter.input_file_type}}"
+    run:
+        op.absolute_symlink(input.{{cookiecutter.input_file_type}}, output.{{cookiecutter.input_file_type}})
+
+# Symlinks the subsetting categories input file into the module results directory (under '00-inputs/')
+rule _{{cookiecutter.module_name}}_input_subsetting_categories:
+    input:
+        subsetting_categories = CFG["inputs"]["subsetting_categories"]
+    output:
+        subsetting_categories = CFG["dirs"]["inputs"] + "sample_sets/subsetting_categories.tsv"
+    run:
+        op.absolute_symlink(input.subsetting_categories, output.subsetting_categories)
+
+# Prepare the {{cookiecutter.input_file_type}} file
+checkpoint _{{cookiecutter.module_name}}_prepare_{{cookiecutter.input_file_type}}:
+    input:
+        {{cookiecutter.input_file_type}} = expand(
+                    str(rules._{{cookiecutter.module_name}}_input_{{cookiecutter.input_file_type}}.output.{{cookiecutter.input_file_type}}),
+                    allow_missing=True,
+                    seq_type=CFG["samples"]["seq_type"].unique()
+                    ),
+        subsetting_categories = str(rules._{{cookiecutter.module_name}}_input_subsetting_categories.output.subsetting_categories)
+    output:
+        CFG["dirs"]["prepare_{{cookiecutter.input_file_type}}"] + "{sample_set}--{projection}--{launch_date}/done"
+    log:
+        CFG["logs"]["prepare_{{cookiecutter.input_file_type}}"] + "{sample_set}--{projection}--{launch_date}/prepare_{{cookiecutter.input_file_type}}.log"
+    conda:
+        CFG["conda_envs"]["prepare"]
+    params:
+        {% if cookiecutter.input_file_type == "maf" %}
+        include_non_coding = str(CFG["include_non_coding"]).upper(),
+        {% endif %}
+        # TODO: remove blank lines here (left here by the cookiecutter template)
+        mode = "<TODO> must match what you used in the generate_smg_inputs lcr-script",
+        metadata_cols = CFG["samples"],
+        metadata_dim = CFG["samples"].shape,
+        metadata = CFG["samples"].to_numpy(na_value='')
+    script:
+        PREPARE_SCRIPT
+  
+
+# Run {{cookiecutter.module_name}} 
+# TODO: Add all expected output files below 
+rule _{{cookiecutter.module_name}}_run:
+    input:
+        {{cookiecutter.input_file_type}} = CFG["dirs"]["prepare_{{cookiecutter.input_file_type}}"] + "{sample_set}--{projection}--{launch_date}/{md5sum}.{{cookiecutter.input_file_type}}"
+    output:
+        {{cookiecutter.output_file_type}} = CFG["dirs"]["{{cookiecutter.module_name}}"] + "{sample_set}--{projection}/{launch_date}--{md5sum}/<TODO>.{{cookiecutter.output_file_type}}"
+    log:
+        stdout = CFG["logs"]["{{cookiecutter.module_name}}"] + "{sample_set}--{projection}/{launch_date}--{md5sum}/{{cookiecutter.module_name}}.stdout.log",
+        stderr = CFG["logs"]["{{cookiecutter.module_name}}"] + "{sample_set}--{projection}/{launch_date}--{md5sum}/{{cookiecutter.module_name}}.stderr.log"
+    params:
+        opts = CFG["options"]["{{cookiecutter.module_name}}_run"]
+    conda:
+        CFG["conda_envs"]["{{cookiecutter.module_name}}"]
+    threads:
+        CFG["threads"]["{{cookiecutter.module_name}}_run"]
+    resources:
+        **CFG["resources"]["{{cookiecutter.module_name}}_run"]
+    shell:
+        op.as_one_line("""
+         <TODO> {params.opts} --input {input.{{cookiecutter.input_file_type}}} --output {output.{{cookiecutter.output_file_type}}} --threads {threads}
+        > {log.stdout} 2> {log.stderr}
+        """)
+
+# Symlinks the final output files into the module results directory (under '99-outputs/')
+# TODO: If applicable, add lines for each file meant to be exposed to the user
+rule _{{cookiecutter.module_name}}_output:
+    input:
+        {{cookiecutter.output_file_type}} = str(rules._{{cookiecutter.module_name}}_run.output.{{cookiecutter.output_file_type}})
+    output:
+        {{cookiecutter.output_file_type}} = CFG["dirs"]["outputs"] + "{sample_set}--{projection}/{launch_date}--{md5sum}/<TODO>.{{cookiecutter.output_file_type}}"
+    run:
+        op.relative_symlink(input.{{cookiecutter.output_file_type}}, output.{{cookiecutter.output_file_type}}, in_module= True)
+
+def _for_aggregate(wildcards):
+    CFG = config["lcr-modules"]["{{cookiecutter.module_name}}"]
+    checkpoint_output = os.path.dirname(str(checkpoints._{{cookiecutter.module_name}}_prepare_{{cookiecutter.input_file_type}}.get(**wildcards).output[0]))
+    SUMS, = glob_wildcards(checkpoint_output +"/{md5sum}.{{cookiecutter.input_file_type}}")
+    return expand(
+        [
+            CFG["dirs"]["outputs"] + "{{ "{{" }}sample_set{{ "}}" }}--{{ "{{" }}projection{{ "}}" }}/{{ "{{" }}launch_date{{ "}}" }}--{md5sum}/<TODO>.{{cookiecutter.output_file_type}}",
+            
+        ],
+        md5sum = SUMS
+        )
+
+# Aggregates outputs to remove md5sum from rule all
+rule _{{cookiecutter.module_name}}_aggregate:
+    input:
+        _for_aggregate
+    output:
+        aggregate = CFG["dirs"]["outputs"] + "{sample_set}--{projection}--{launch_date}.done"
+    shell:
+        op.as_one_line("""touch {output.aggregate}""")
+
+
+rule _{{cookiecutter.module_name}}_all:
+    input:
+        expand(
+            [
+                CFG["dirs"]["prepare_{{cookiecutter.input_file_type}}"] + "{sample_set}--{projection}--{launch_date}/done",
+                str(rules._{{cookiecutter.module_name}}_aggregate.output.aggregate)
+            ],
+            projection = CFG["projections"],
+            sample_set = CFG["sample_set"],
+            launch_date = launch_date
+        )
+
+##### CLEANUP #####
+
+
+# Perform some clean-up tasks, including storing the module-specific
+# configuration on disk and deleting the `CFG` variable
+op.cleanup_module(CFG)

--- a/template-level3/{{cookiecutter.module_name}}/1.0/{{cookiecutter.module_name}}.smk
+++ b/template-level3/{{cookiecutter.module_name}}/1.0/{{cookiecutter.module_name}}.smk
@@ -110,10 +110,10 @@ checkpoint _{{cookiecutter.module_name}}_prepare_{{cookiecutter.input_file_type}
         metadata = CFG["samples"].to_numpy(na_value='')
     script:
         PREPARE_SCRIPT
-  
 
-# Run {{cookiecutter.module_name}} 
-# TODO: Add all expected output files below 
+
+# Run {{cookiecutter.module_name}}
+# TODO: Add all expected output files below
 rule _{{cookiecutter.module_name}}_run:
     input:
         {{cookiecutter.input_file_type}} = CFG["dirs"]["prepare_{{cookiecutter.input_file_type}}"] + "{sample_set}--{projection}--{launch_date}/{md5sum}.{{cookiecutter.input_file_type}}"
@@ -153,7 +153,7 @@ def _for_aggregate(wildcards):
     return expand(
         [
             CFG["dirs"]["outputs"] + "{{ "{{" }}sample_set{{ "}}" }}--{{ "{{" }}projection{{ "}}" }}/{{ "{{" }}launch_date{{ "}}" }}--{md5sum}/<TODO>.{{cookiecutter.output_file_type}}",
-            
+
         ],
         md5sum = SUMS
         )
@@ -186,3 +186,4 @@ rule _{{cookiecutter.module_name}}_all:
 # Perform some clean-up tasks, including storing the module-specific
 # configuration on disk and deleting the `CFG` variable
 op.cleanup_module(CFG)
+

--- a/template-level3/{{cookiecutter.module_name}}/CHANGELOG.md
+++ b/template-level3/{{cookiecutter.module_name}}/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to the `{{cookiecutter.module_name}}` module will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0] - {% now 'local' %}
+
+This release was authored by {{cookiecutter.module_author}}.
+
+<!-- TODO: Explain each important module design decision below. -->
+
+- No module design decisions explained here yet.


### PR DESCRIPTION
Created directory `template-level3` that holds the necessary files

Tested by running:
```
cookiecutter "template-level3/" --output-dir 'modules/'
```
with each option for input file type, `maf` or `seg`. 

It is set up to have the same `pairing_config:` section of the `default.yaml` with only genome and capture sections. This can be extended in the future if needed.

Also updated the Developer docs.
