### PR TITLE
Update CNV callers

### DIFF
--- a/modules/battenberg/1.1/battenberg.smk
+++ b/modules/battenberg/1.1/battenberg.smk
@@ -14,6 +14,7 @@
 # Import package with useful functions for developing analysis modules
 import oncopipe as op
 import glob
+import pandas as pd
 
 # Check that the oncopipe dependency is up-to-date. Add all the following lines to any module that uses new features in oncopipe
 min_oncopipe_version="1.0.11"
@@ -168,7 +169,7 @@ rule _battenberg_fill_subclones:
     threads: 1
     group: "battenberg_post_process"
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/",
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"],
         script = "fill_segments.sh",
         arm_file = lambda w: "src/chromArm.hg38.bed" if "38" in str({w.genome_build}) else "src/chromArm.grch37.bed",
         blacklist_file = lambda w: "src/blacklisted.hg38.bed" if "38" in str({w.genome_build}) else "src/blacklisted.grch37.bed"
@@ -288,7 +289,7 @@ rule _battenberg_fill_segments:
     threads: 1
     group: "battenberg_post_process"
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/"
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"]
     conda:
         CFG["conda_envs"]["bedtools"]
     shell:

--- a/modules/battenberg/1.1/config/default.yaml
+++ b/modules/battenberg/1.1/config/default.yaml
@@ -23,6 +23,7 @@ lcr-modules:
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
             prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
             non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
+            fill_segments_version: "1.1/"
 
         conda_envs:
             battenberg: "{MODSDIR}/envs/battenberg-1.1.yaml"

--- a/modules/battenberg/1.2/battenberg.smk
+++ b/modules/battenberg/1.2/battenberg.smk
@@ -226,7 +226,7 @@ rule _battenberg_fill_subclones:
     threads: 1
     group: "battenberg_post_process"
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/",
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"],
         script = "fill_segments.sh",
         arm_file = lambda w: "src/chromArm.hg38.bed" if "38" in str({w.genome_build}) else "src/chromArm.grch37.bed",
         blacklist_file = lambda w: "src/blacklisted.hg38.bed" if "38" in str({w.genome_build}) else "src/blacklisted.grch37.bed"
@@ -346,7 +346,7 @@ rule _battenberg_fill_segments:
     threads: 1
     group: "battenberg_post_process"
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/"
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"]
     conda:
         CFG["conda_envs"]["bedtools"]
     shell:

--- a/modules/battenberg/1.2/config/default.yaml
+++ b/modules/battenberg/1.2/config/default.yaml
@@ -21,6 +21,7 @@ lcr-modules:
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
             prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
             non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
+            fill_segments_version: "1.1/"
 
         output: # specify the naming convention for the output files under 99-outputs/
                 # required wildcards to use are {seq_type}, {tumour_id}, {normal_id}, {pair_status}, {tool}

--- a/modules/cnvkit/1.0/cnvkit.smk
+++ b/modules/cnvkit/1.0/cnvkit.smk
@@ -676,7 +676,7 @@ rule _cnvkit_fill_segments:
         stderr = CFG["logs"]["fill_regions"] + "{seq_type}--projection/{tumour_id}--{normal_id}--{pair_status}.{tool}_fill_segments.stderr.log"
     threads: 1
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/"
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"]
     conda:
         CFG["conda_envs"]["bedtools"]
     group: "cnvkit_post_process"

--- a/modules/cnvkit/1.0/config/default.yaml
+++ b/modules/cnvkit/1.0/config/default.yaml
@@ -71,6 +71,7 @@ lcr-modules:
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
             prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
             non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
+            fill_segments_version: "1.1/"
 
         output: # specify the naming convention for the output files under 99-outputs/
                 # required wildcards to use are {seq_type}, {tumour_id}, {normal_id}, {pair_status}, {tool}

--- a/modules/controlfreec/1.2/config/default.yaml
+++ b/modules/controlfreec/1.2/config/default.yaml
@@ -71,6 +71,7 @@ lcr-modules:
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
             prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
             non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
+            fill_segments_version: "1.1/"
 
         output: # specify the naming convention for the output files under 99-outputs/
                 # required wildcards to use are {seq_type}, {tumour_id}, {normal_id}, {pair_status}, {tool}

--- a/modules/controlfreec/1.2/controlfreec.smk
+++ b/modules/controlfreec/1.2/controlfreec.smk
@@ -591,7 +591,7 @@ rule _controlfreec_fill_segments:
         stderr = CFG["logs"]["fill_regions"] + "{seq_type}--projection/{tumour_id}--{normal_id}--{pair_status}.{tool}_fill_segments.stderr.log"
     threads: 1
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/"
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"]
     conda:
         CFG["conda_envs"]["bedtools"]
     group: "controlfreec_post_process"

--- a/modules/sequenza/1.4/config/default.yaml
+++ b/modules/sequenza/1.4/config/default.yaml
@@ -22,6 +22,7 @@ lcr-modules:
             liftover_minMatch: "0.95" # Float number from 0 to 1 indicating minimal mapping when converting to a different genome build
             prefixed_projections: ["grch38", "hg38"] # List here the base names of chr-prefixed projections
             non_prefixed_projections: ["grch37", "hg19", "hs37d5"] # List here the base names of non-prefixed projections
+            fill_segments_version: "1.1/"
 
         conda_envs:
             sequenza-utils: "{MODSDIR}/envs/sequenza-utils-3.0.0.yaml"

--- a/modules/sequenza/1.4/sequenza.smk
+++ b/modules/sequenza/1.4/sequenza.smk
@@ -226,7 +226,7 @@ rule _sequenza_fill_txt:
     threads: 1
     group: "sequenza_post_process"
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/",
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"],
         script = "fill_segments.sh",
         arm_file = lambda w: "src/chromArm.hg38.bed" if "38" in str({w.genome_build}) else "src/chromArm.grch37.bed",
         blacklist_file = lambda w: "src/blacklisted.hg38.bed" if "38" in str({w.genome_build}) else "src/blacklisted.grch37.bed"
@@ -348,7 +348,7 @@ rule _sequenza_fill_segments:
         stderr = CFG["logs"]["fill_regions"] + "{seq_type}--projection/{tumour_id}--{normal_id}--{pair_status}.{tool}_fill_segments.stderr.log"
     threads: 1
     params:
-        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/1.0/"
+        path = config["lcr-modules"]["_shared"]["lcr-scripts"] + "fill_segments/" + CFG["options"]["fill_segments_version"]
     conda:
         CFG["conda_envs"]["bedtools"]
     group: "sequenza_post_process"


### PR DESCRIPTION
The version of fill_segments was hard-coded across the board and was not flexible. This update allows user to specify which version of that script they want to use through config, and this bug fixes all of battenberg 1.1, 1.2, sequenza, controlfreec, and cnvkit 🙌 