### PR TITLE
Module/modkit/1.0

### DIFF
--- a/envs/modkit/modkit-0.4.2.yaml
+++ b/envs/modkit/modkit-0.4.2.yaml
@@ -1,0 +1,14 @@
+name: modkit
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - _libgcc_mutex=0.1
+  - _openmp_mutex=4.5
+  - libgcc=14.2.0
+  - libgomp=14.2.0
+  - libstdcxx=14.2.0
+  - libzlib=1.3.1
+  - ont-modkit=0.4.2
+prefix: /home/hshaalan/miniconda3/envs/modkit

--- a/modules/modkit/1.0/config/default.yaml
+++ b/modules/modkit/1.0/config/default.yaml
@@ -17,9 +17,6 @@ lcr-modules:
         threads:
             pileup: 8
 
-        options:
-            header: "chrom\tstart\tend\tmodified_base_code\tscore\tstrand\tstart_position\tend_position\tcolor\tNvalid_cov\tpercent_modified\tNmod\tNcanonical\tNother_mod\tNdelete\tNfail\tNdiff\tNnocall"
-
         resources:
             modkit: 
                 mem_mb: 2000

--- a/modules/modkit/1.0/config/default.yaml
+++ b/modules/modkit/1.0/config/default.yaml
@@ -8,7 +8,7 @@ lcr-modules:
             sample_bam: "__UPDATE__"
             sample_bai: "__UPDATE__"
 
-        scratch_subdirectories: ["/projects/nhl_meta_analysis_scratch/"]
+        scratch_subdirectories: []
 
 
         conda_envs:

--- a/modules/modkit/1.0/config/default.yaml
+++ b/modules/modkit/1.0/config/default.yaml
@@ -2,7 +2,6 @@ lcr-modules:
     
     modkit:
 
-        # TODO: Update the list of available wildcards, if applicable
         inputs:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_bam: "__UPDATE__"
@@ -22,7 +21,7 @@ lcr-modules:
             header: "chrom\tstart\tend\tmodified_base_code\tscore\tstrand\tstart_position\tend_position\tcolor\tNvalid_cov\tpercent_modified\tNmod\tNcanonical\tNother_mod\tNdelete\tNfail\tNdiff\tNnocall"
 
         resources:
-            step_1: 
+            modkit: 
                 mem_mb: 2000
             
         pairing_config:

--- a/modules/modkit/1.0/config/default.yaml
+++ b/modules/modkit/1.0/config/default.yaml
@@ -1,0 +1,30 @@
+lcr-modules:
+    
+    modkit:
+
+        # TODO: Update the list of available wildcards, if applicable
+        inputs:
+            # Available wildcards: {seq_type} {genome_build} {sample_id}
+            sample_bam: "__UPDATE__"
+
+        scratch_subdirectories: []
+
+        options:
+            step_1: ""
+            step_2: ""
+
+        conda_envs:
+            samtools: "{MODSDIR}/envs/samtools-1.9.yaml"
+            
+        threads:
+            step_1: 4
+
+        resources:
+            step_1: 
+                mem_mb: 2000
+            
+        pairing_config:
+            genome:
+                run_paired_tumours: False
+                run_unpaired_tumours_with: "no_normal"
+                run_paired_tumours_as_unpaired: True

--- a/modules/modkit/1.0/config/default.yaml
+++ b/modules/modkit/1.0/config/default.yaml
@@ -6,18 +6,20 @@ lcr-modules:
         inputs:
             # Available wildcards: {seq_type} {genome_build} {sample_id}
             sample_bam: "__UPDATE__"
+            sample_bai: "__UPDATE__"
 
-        scratch_subdirectories: []
+        scratch_subdirectories: ["/projects/nhl_meta_analysis_scratch/"]
 
-        options:
-            step_1: ""
-            step_2: ""
 
         conda_envs:
             samtools: "{MODSDIR}/envs/samtools-1.9.yaml"
+            modkit: "{MODSDIR}/envs/modkit-0.4.2.yaml"
             
         threads:
-            step_1: 4
+            pileup: 8
+
+        options:
+            header: "chrom\tstart\tend\tmodified_base_code\tscore\tstrand\tstart_position\tend_position\tcolor\tNvalid_cov\tpercent_modified\tNmod\tNcanonical\tNother_mod\tNdelete\tNfail\tNdiff\tNnocall"
 
         resources:
             step_1: 

--- a/modules/modkit/1.0/envs/modkit-0.4.2.yaml
+++ b/modules/modkit/1.0/envs/modkit-0.4.2.yaml
@@ -1,0 +1,1 @@
+/projects/rmorin/projects/gambl-repos/gambl-hshaalan/src/lcr-modules/envs/modkit/modkit-0.4.2.yaml

--- a/modules/modkit/1.0/envs/samtools-1.9.yaml
+++ b/modules/modkit/1.0/envs/samtools-1.9.yaml
@@ -1,0 +1,1 @@
+../../../../envs/samtools/samtools-1.9.yaml

--- a/modules/modkit/1.0/modkit.smk
+++ b/modules/modkit/1.0/modkit.smk
@@ -1,0 +1,141 @@
+#!/usr/bin/env snakemake
+
+
+##### ATTRIBUTION #####
+
+
+# Original Author:  Haya Shaalan
+# Module Author:    Haya Shaalan
+# Contributors:     N/A
+
+
+##### SETUP #####
+
+# Import package with useful functions for developing analysis modules
+import oncopipe as op
+
+# Check that the oncopipe dependency is up-to-date. Add all the following lines to any module that uses new features in oncopipe
+min_oncopipe_version="1.0.11"
+import pkg_resources
+try:
+    from packaging import version
+except ModuleNotFoundError:
+    sys.exit("The packaging module dependency is missing. Please install it ('pip install packaging') and ensure you are using the most up-to-date oncopipe version")
+
+# To avoid this we need to add the "packaging" module as a dependency for LCR-modules or oncopipe
+
+current_version = pkg_resources.get_distribution("oncopipe").version
+if version.parse(current_version) < version.parse(min_oncopipe_version):
+    print('\x1b[0;31;40m' + f'ERROR: oncopipe version installed: {current_version}' + '\x1b[0m')
+    print('\x1b[0;31;40m' + f"ERROR: This module requires oncopipe version >= {min_oncopipe_version}. Please update oncopipe in your environment" + '\x1b[0m')
+    sys.exit("Instructions for updating to the current version of oncopipe are available at https://lcr-modules.readthedocs.io/en/latest/ (use option 2)")
+
+# End of dependency checking section
+
+# Setup module and store module-specific configuration in `CFG`
+# `CFG` is a shortcut to `config["lcr-modules"]["modkit"]`
+CFG = op.setup_module(
+    name = "modkit",
+    version = "1.0",
+    # TODO: If applicable, add more granular output subdirectories
+    subdirectories = ["inputs", "modkit", "outputs"],
+)
+
+# Define rules to be run locally when using a compute cluster
+# TODO: Replace with actual rules once you change the rule names
+localrules:
+    _modkit_input_bam,
+    _modkit_step_2,
+    _modkit_output_tsv,
+    _modkit_all,
+
+
+##### RULES #####
+
+
+# Symlinks the input files into the module results directory (under '00-inputs/')
+# TODO: If applicable, add an input rule for each input file used by the module
+# TODO: If applicable, create second symlink to .crai file in the input function, to accomplish cram support
+rule _modkit_input_bam:
+    input:
+        bam = CFG["inputs"]["sample_bam"]
+    output:
+        bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam"
+    group: 
+        "input_and_step_1"
+    run:
+        op.absolute_symlink(input.bam, output.bam)
+
+
+# Example variant calling rule (multi-threaded; must be run on compute server/cluster)
+# TODO: Replace example rule below with actual rule
+rule _modkit_step_1:
+    input:
+        bam = str(rules._modkit_input_bam.output.bam),
+        fasta = reference_files("genomes/{genome_build}/genome_fasta/genome.fa")
+    output:
+        tsv = CFG["dirs"]["modkit"] + "{seq_type}--{genome_build}/{sample_id}/output.tsv"
+    log:
+        stdout = CFG["logs"]["modkit"] + "{seq_type}--{genome_build}/{sample_id}/step_1.stdout.log",
+        stderr = CFG["logs"]["modkit"] + "{seq_type}--{genome_build}/{sample_id}/step_1.stderr.log"
+    params:
+        opts = CFG["options"]["step_1"]
+    conda:
+        CFG["conda_envs"]["samtools"]
+    threads:
+        CFG["threads"]["step_1"]
+    resources:
+        **CFG["resources"]["step_1"]    # All resources necessary can be included and referenced from the config files.
+    shell:
+        op.as_one_line("""
+        <TODO> {params.opts} --input {input.bam} --ref-fasta {input.fasta}
+        --output {output.tsv} --threads {threads} > {log.stdout} 2> {log.stderr}
+        """)
+
+
+# Example variant filtering rule (single-threaded; can be run on cluster head node)
+# TODO: Replace example rule below with actual rule
+rule _modkit_step_2:
+    input:
+        tsv = str(rules._modkit_step_1.output.tsv)
+    output:
+        tsv = CFG["dirs"]["modkit"] + "{seq_type}--{genome_build}/{sample_id}/output.filt.tsv"
+    log:
+        stderr = CFG["logs"]["modkit"] + "{seq_type}--{genome_build}/{sample_id}/step_2.stderr.log"
+    params:
+        opts = CFG["options"]["step_2"]
+    shell:
+        "grep {params.opts} {input.tsv} > {output.tsv} 2> {log.stderr}"
+
+
+# Symlinks the final output files into the module results directory (under '99-outputs/')
+# TODO: If applicable, add an output rule for each file meant to be exposed to the user
+rule _modkit_output_tsv:
+    input:
+        tsv = str(rules._modkit_step_2.output.tsv)
+    output:
+        tsv = CFG["dirs"]["outputs"] + "tsv/{seq_type}--{genome_build}/{sample_id}.output.filt.tsv"
+    run:
+        op.relative_symlink(input.tsv, output.tsv, in_module= True)
+
+
+# Generates the target sentinels for each run, which generate the symlinks
+rule _modkit_all:
+    input:
+        expand(
+            [
+                str(rules._modkit_output_tsv.output.tsv),
+                # TODO: If applicable, add other output rules here
+            ],
+            zip,  # Run expand() with zip(), not product()
+            seq_type=CFG["samples"]["seq_type"],
+            genome_build=CFG["samples"]["genome_build"],
+            sample_id=CFG["samples"]["sample_id"])
+
+
+##### CLEANUP #####
+
+
+# Perform some clean-up tasks, including storing the module-specific
+# configuration on disk and deleting the `CFG` variable
+op.cleanup_module(CFG)

--- a/modules/modkit/1.0/schemas/base-1.0.yaml
+++ b/modules/modkit/1.0/schemas/base-1.0.yaml
@@ -1,0 +1,1 @@
+../../../../schemas/base/base-1.0.yaml

--- a/modules/modkit/CHANGELOG.md
+++ b/modules/modkit/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to the `modkit` module will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0] - 2025-02-18
+
+This release was authored by Haya Shaalan.
+
+The basecaller Dorado converts raw signal of reads from Oxford Nanopore Technologies (ONT) long read sequencing to basecalls. Dorado records base modifications such as methylated cytosines in MM and ML tags of BAM files. Modkit is a tool developed by ONT and is used to convert modBAMs to bedMethyl files.
+
+
+


### PR DESCRIPTION
Modkit is a tool developed by ONT and is used to convert modBAMs to bedMethyl files.

# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for New Module

### Required

- [ ] I used the cookiecutter template and updated the placeholder rules.

- [ ] The snakemake rules follow the [design guidelines](https://lcr-modules.readthedocs.io/en/latest/for_developers.html#module-rules).

  - [ ] All references to the `rules` object (_e.g._ for input files) are wrapped with `str()`.

- [ ] Every rule in the module is either listed under `localrules` or has the `threads` and `resources` directives.

- [ ] Input and output files are being symlinked into the `CFG["inputs"]` and `CFG["outputs"]` subdirectories, respectively.

- [ ] I grouped the input symlinking rule to the next job that uses the input files.

- [ ] I updated the final target rule (`*_all`) to include every output rule.

- [ ] I explained important module design decisions in `CHANGELOG.md`.

- [ ] I tested the module on real data for all supported `seq_type` values.

- [ ] I updated the `default.yaml` configuration file to provide default values for each rule in the module snakefile.

- [ ] I did not set any global wildcard constraints. Any/all wildcard constraints are set on a per-rule basis.

- [ ] I ensured that all symbolic links are relative and self-contained (_i.e._ do not point outside of the repository).

- [ ] I replaced every value that should (or might need to) be updated in the default configuration file with `__UPDATE__`.

- [ ] I recursively searched for all comments containing `TODO` to ensure none were left. For example:

  ```bash
  grep -r TODO modules/<module_name>/1.0
  ```

### If applicable

- [ ] I added more granular output subdirectories.

- [ ] I added rules to the `reference_files` workflow to generate any new reference files.

- [ ] I added subdirectories with large intermediate files to the list of `scratch_subdirectories` in the `default.yaml` configuration file.

- [ ] I updated the list of available wildcards for the input files in the `default.yaml` configuration file.

## Checklist for Updated Module

Important! If you are updating the module version, ensure the previous version of the module is restored from master.
If you want to restore a deleted file or directory from the remote master, you can use `git checkout origin/master path/to/file`,
then a `git commit` will ensure that file is tracked on your branch again.
Example:
```
mv modules/strelka/1.1 modules/strelka/1.2
git checkout origin/master modules/strelka/1.1
```

Once moved to the new directory, change the version number in the `op.setup_module` section of the snakefile, .e.g
```
CFG = op.setup_module(
    name = "strelka",
    version = "1.2",
    subdirectories = ["inputs", "chrom_bed", "strelka", "filtered", "outputs"]
)
```