### PR TITLE
Fix temp() filename collision in get_main_chromosomes_withY_download

### DIFF
--- a/workflows/reference_files/2.4/reference_files.smk
+++ b/workflows/reference_files/2.4/reference_files.smk
@@ -184,7 +184,7 @@ rule get_main_chromosomes_withY_download:
     output:
         txt = "genomes/{genome_build}/genome_fasta/main_chromosomes_withY.txt",
         bed = "genomes/{genome_build}/genome_fasta/main_chromosomes_withY.bed",
-        patterns = temp("genomes/{genome_build}/genome_fasta/main_chromosomes.patterns.txt")
+        patterns = temp("genomes/{genome_build}/genome_fasta/main_chromosomes_withY.patterns.txt")
     conda: CONDA_ENVS["coreutils"]
     shell:
         op.as_one_line("""

--- a/workflows/reference_files/2.5/reference_files.smk
+++ b/workflows/reference_files/2.5/reference_files.smk
@@ -184,7 +184,7 @@ rule get_main_chromosomes_withY_download:
     output:
         txt = "genomes/{genome_build}/genome_fasta/main_chromosomes_withY.txt",
         bed = "genomes/{genome_build}/genome_fasta/main_chromosomes_withY.bed",
-        patterns = temp("genomes/{genome_build}/genome_fasta/main_chromosomes.patterns.txt")
+        patterns = temp("genomes/{genome_build}/genome_fasta/main_chromosomes_withY.patterns.txt")
     conda: CONDA_ENVS["coreutils"]
     shell:
         op.as_one_line("""


### PR DESCRIPTION
## Bug

Two rules in `workflows/reference_files/2.4/reference_files.smk` and `2.5/reference_files.smk` declare the same `temp()` output path:

- `rule get_main_chromosomes_download`
- `rule get_main_chromosomes_withY_download`

Both produce `genomes/{genome_build}/genome_fasta/main_chromosomes.patterns.txt` as their `temp()` output.

When Snakemake schedules the two rules in parallel (default behaviour with `--jobs > 1`), whichever finishes first triggers `temp()` cleanup of the shared file. The still-running rule's `egrep -w -f {output.patterns}` then reads a now-deleted patterns file, the `&&` chain breaks mid-pipeline, and the rule's other outputs (`main_chromosomes.txt`, `main_chromosomes.bed`, `chromosome_x.txt`) are never written. Snakemake exits 0 but flags the missing outputs after the latency-wait window with:

> completed successfully, but some output files are missing

The collision was introduced in v2.4 when `get_main_chromosomes_withY_download` was added; v2.5 inherited it. Earlier versions (1.0–2.3) had only the original rule and so did not collide.

## Reproduction

A clean grch37 reference build with `--jobs ≥ 2` reproduces this non-deterministically — anywhere from one in three to almost every run, depending on rule scheduling order.

## Fix

Give each rule a unique patterns filename. The rule's shell uses `{output.patterns}` so the rename auto-propagates.

```diff
 rule get_main_chromosomes_withY_download:
     ...
     output:
         txt = \"genomes/{genome_build}/genome_fasta/main_chromosomes_withY.txt\",
         bed = \"genomes/{genome_build}/genome_fasta/main_chromosomes_withY.bed\",
-        patterns = temp(\"genomes/{genome_build}/genome_fasta/main_chromosomes.patterns.txt\")
+        patterns = temp(\"genomes/{genome_build}/genome_fasta/main_chromosomes_withY.patterns.txt\")
```

## Safety check

Verified via grep across the entire lcr-modules tree that `main_chromosomes.patterns.txt` is referenced only inside the two rule definitions themselves — it's pure internal scratch with no external consumers (no module, no other reference rule, no downstream workflow uses it by name). The downstream-consumed files (`main_chromosomes.txt`, `main_chromosomes.bed`, `main_chromosomes_withY.txt`, `chromosome_x.txt`) keep their existing names. The rename is therefore side-effect-free.

## Testing

Reproduced the bug on a fresh grch37 reference build with `--jobs 16`. After applying this patch, the same build completes successfully on retry.