### PR TITLE
Update ChromosomeMappings repo to LCR-BCCRC

### DIFF
--- a/workflows/reference_files/1.0/reference_files.smk
+++ b/workflows/reference_files/1.0/reference_files.smk
@@ -82,7 +82,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)

--- a/workflows/reference_files/2.0/reference_files_header.smk
+++ b/workflows/reference_files/2.0/reference_files_header.smk
@@ -82,7 +82,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)

--- a/workflows/reference_files/2.1/reference_files_header.smk
+++ b/workflows/reference_files/2.1/reference_files_header.smk
@@ -82,7 +82,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)

--- a/workflows/reference_files/2.2/reference_files_header.smk
+++ b/workflows/reference_files/2.2/reference_files_header.smk
@@ -82,7 +82,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)

--- a/workflows/reference_files/2.3/reference_files_header.smk
+++ b/workflows/reference_files/2.3/reference_files_header.smk
@@ -80,7 +80,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)

--- a/workflows/reference_files/2.4/reference_files_header.smk
+++ b/workflows/reference_files/2.4/reference_files_header.smk
@@ -138,7 +138,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)

--- a/workflows/reference_files/2.5/reference_files_header.smk
+++ b/workflows/reference_files/2.5/reference_files_header.smk
@@ -137,7 +137,7 @@ wildcard_constraints:
 
 # Define method for download ChromosomeMappings repository
 def download_chrom_mappings(chrom_mappings_dir):
-    chrom_mappings_url = "https://github.com/BrunoGrandePhD/ChromosomeMappings/archive/master.tar.gz"
+    chrom_mappings_url = "https://github.com/LCR-BCCRC/ChromosomeMappings/archive/master.tar.gz"
     tar_file_path = "ChromosomeMappings.tar.gz"
     os.makedirs("./", exist_ok=True)
     urllib.request.urlretrieve(chrom_mappings_url, tar_file_path)


### PR DESCRIPTION
The original ChromosomeMappings repo (forked by Bruno) had a typo in one GRCm37 file name that was causing an error when running the reference_files workflow. This updates to a new fork stored in LCR-BCCRC with the correct filename. See https://morinlabsfu.slack.com/archives/CUCMSL2N8/p1784564035469619. 