### PR TITLE
Module/deepsomatic pr

### DIFF
--- a/modules/deepsomatic/1.0/config/default.yaml
+++ b/modules/deepsomatic/1.0/config/default.yaml
@@ -2,7 +2,7 @@ lcr-modules:
     
     deepsomatic:
 
-# When calling this snakemake workflow, use --use-singularity as a flag
+# Running this module requires containers to run DeepSomatic, conda support does not exist for the _deepsomatic_call_variants rule
 # Additional required columns in your samples table: "chemistry"
 # Chemistry is the version of pore chemistry used to sequence a particular sample
     # Available values: R9, R10

--- a/modules/deepsomatic/1.0/config/default.yaml
+++ b/modules/deepsomatic/1.0/config/default.yaml
@@ -1,0 +1,61 @@
+lcr-modules:
+    
+    deepsomatic:
+
+# When calling this snakemake workflow, use --use-singularity as a flag
+# Additional required columns in your samples table: "chemistry"
+# Chemistry is the version of pore chemistry used to sequence a particular sample
+    # Available values: R9, R10
+    # It is recommended to avoid using this module with R9 samples
+# This module is intended to work with an unmatched normal
+
+        inputs:
+          # Available wildcards: {seq_type} {genome_build} {sample_id} {chemistry} {platform} {normal_name}
+          sample_bam: "__UPDATE__"
+          sample_bai: "__UPDATE__"
+          normal_bam: "__UPDATE__"
+          normal_bai: "__UPDATE__"
+
+        scratch_subdirectories: [] # Suggested: "deepsomatic"
+
+        options:
+          version_map:
+            hg38: "38"
+          seqtype_map:
+            promethION: "promethION"
+          normal_name:
+            R9: "__UPDATE__" # Update this with the prefix for your R9 normal BAM file
+            R10: "__UPDATE__" # Update this with the prefix for your R10 normal BAM file
+          calling_mode: "unmatched" # Available values: unmatched, tumour_only (using tumor_only will run DeepSomaic in its tumor_only mode)
+          deepsomatic_args: "" # Update this with additional DeepSomatic arguments if you wish to use any
+          filters: # Update if you wish to use different filters
+            min_depth: 8
+            snv_min_vaf: 0.10
+            snv_min_alt_depth: 3
+            indel_min_vaf: 0.15
+            indel_min_alt_depth: 6
+            normal_min_depth: 10
+            normal_max_af: 0.05
+        conda_envs:
+          bcftools: "{MODSDIR}/envs/bcftools-1.10.2.yaml"
+
+        container_envs:
+          deepsomatic: "docker://google/deepsomatic:1.10.0" # Change this if you wish to use a different version of DeepSomatic
+          bcftools: "docker://quay.io/biocontainers/bcftools:1.10.2--h4f4756c_3"
+
+        threads:
+          deepsomatic: 24
+          bcftools: 4
+
+        resources:
+          deepsomatic: 
+            mem_mb: 32000 # DeepSomatic requires massive amounts of memory for ONT WGS data. This value will likely need to be increased to somewhere in the range of 72000-96000
+            bam: 1
+          bcftools:
+            mem_mb: 5000
+            
+        pairing_config:
+          promethION:
+            run_paired_tumours: False
+            run_unpaired_tumours_with: "no_normal"
+            run_paired_tumours_as_unpaired: True

--- a/modules/deepsomatic/1.0/deepsomatic.smk
+++ b/modules/deepsomatic/1.0/deepsomatic.smk
@@ -1,0 +1,403 @@
+#!/usr/bin/env snakemake
+
+
+##### ATTRIBUTION #####
+
+
+# Original Author:  Giuliano Banco
+# Module Author:    Giuliano Banco
+# Contributors:     N/A
+
+
+##### SETUP #####
+
+# Import package with useful functions for developing analysis modules
+import oncopipe as op
+import os
+
+# Check that the oncopipe dependency is up-to-date. Add all the following lines to any module that uses new features in oncopipe
+min_oncopipe_version="1.0.11"
+import pkg_resources
+try:
+    from packaging import version
+except ModuleNotFoundError:
+    sys.exit("The packaging module dependency is missing. Please install it ('pip install packaging') and ensure you are using the most up-to-date oncopipe version")
+
+# To avoid this we need to add the "packaging" module as a dependency for LCR-modules or oncopipe
+
+current_version = pkg_resources.get_distribution("oncopipe").version
+if version.parse(current_version) < version.parse(min_oncopipe_version):
+    print('\x1b[0;31;40m' + f'ERROR: oncopipe version installed: {current_version}' + '\x1b[0m')
+    print('\x1b[0;31;40m' + f"ERROR: This module requires oncopipe version >= {min_oncopipe_version}. Please update oncopipe in your environment" + '\x1b[0m')
+    sys.exit("Instructions for updating to the current version of oncopipe are available at https://lcr-modules.readthedocs.io/en/latest/ (use option 2)")
+
+# End of dependency checking section
+
+# Setup module and store module-specific configuration in `CFG`
+# `CFG` is a shortcut to `config["lcr-modules"]["deepsomatic"]`
+CFG = op.setup_module(
+    name = "deepsomatic",
+    version = "1.0",
+    subdirectories = ["inputs", "deepsomatic_temp", "deepsomatic_output", "filter", "gnomad", "outputs"],
+)
+
+# Define rules to be run locally when using a compute cluster
+localrules:
+    _deepsomatic_input_bam,
+    _deepsomatic_input_normal_bam,
+    _deepsomatic_output_vcf,
+    _cleanup_intermediate_dir,
+    _deepsomatic_all
+
+
+VERSION_MAP_DEEPSOMATIC = CFG["options"]["version_map"]
+SEQTYPE_MAP_DEEPSOMATIC = CFG["options"]["seqtype_map"]
+
+possible_genome_builds = ", ".join(list(VERSION_MAP_DEEPSOMATIC.keys()))
+for genome_build in CFG["runs"]["tumour_genome_build"]:
+    assert genome_build in possible_genome_builds, (
+        f"Samples table includes genome builds not yet compatible with this module. "
+        f"This module is currently only compatible with {possible_genome_builds}. "
+    )
+
+possible_seq_types = ", ".join(list(SEQTYPE_MAP_DEEPSOMATIC.keys()))
+for seq_type in CFG["runs"]["tumour_seq_type"]:
+    assert seq_type in possible_seq_types, (
+        f"Samples table includes seq types not yet compatible with this module. "
+        f"This module is currently only compatible with {possible_seq_types}. "
+    )
+
+
+chemistry = CFG["runs"]["tumour_chemistry"]
+
+normal_map = CFG["options"]["normal_name"]
+
+CFG["runs"]["normal_name"] = CFG["runs"]["tumour_chemistry"].map(normal_map)
+
+if CFG["runs"]["normal_name"].isna().any():
+    missing = CFG["runs"].loc[CFG["runs"]["normal_name"].isna(), "tumour_chemistry"].unique()
+    print(f"Warning: some chemistry values have no mapping in normal_name. Available chemistry values: R9, R10")
+
+
+##### RULES #####
+
+
+# Input tumor bam
+# Symlinks the input files into the module results directory (under '00-inputs/')
+rule _deepsomatic_input_bam:
+    input:
+        bam = CFG["inputs"]["sample_bam"],
+        bai = CFG["inputs"]["sample_bai"]
+    output:
+        bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{tumour_id}.bam",
+        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{tumour_id}.bam.bai",
+        crai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{tumour_id}.bam.crai"
+    run:
+        op.absolute_symlink(input.bam, output.bam)
+        op.absolute_symlink(input.bai, output.bai)
+        op.absolute_symlink(input.bai, output.crai)
+
+
+# Input normal bam
+# Symlinks the input files into the module results directory (under '00-inputs/')
+rule _deepsomatic_input_normal_bam:
+    input:
+        bam = CFG["inputs"]["normal_bam"],
+        bai = CFG["inputs"]["normal_bai"],
+        normal_name = CFG["runs"]["normal_name"]
+    output:
+        bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{normal_name}.bam",
+        bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{normal_name}.bam.bai",
+        crai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{normal_name}.bam.crai"
+    run:
+        op.absolute_symlink(input.bam, output.bam)
+        op.absolute_symlink(input.bai, output.bai)
+        op.absolute_symlink(input.bai, output.crai)
+
+
+# Helper function to fetch normal_name for the unmatched normal bam file depending on sample chemistry
+def get_normal(wildcards):
+    CFG = config["lcr-modules"]["deepsomatic"]
+    this_sample = op.filter_samples(
+        CFG["runs"],
+        sample_id = wildcards.tumour_id,
+        seq_type = wildcards.seq_type, 
+        genome_build = wildcards.genome_build
+    )
+    normal = this_sample["normal_name"].tolist()[0]
+    return normal
+
+# Fetch calling mode from config (either unmatched or tumor_only)
+DEEPSOMATIC_CALLING_MODE = CFG["options"]["calling_mode"]
+
+# Map calling mode to the appropriate DeepSomatic model
+DEEPSOMATIC_MODEL_TYPES = {
+    "unmatched": "ONT",
+    "tumor_only": "ONT_TUMOR_ONLY",
+}
+
+# Map calling mode to the name used in output directories
+DEEPSOMATIC_CALLING_MODE_DIRS = {
+    "unmatched": "unmatched",
+    "tumor_only": "tumour-only",
+}
+
+# Throw an error if calling_mode is not one of the accepted values
+if DEEPSOMATIC_CALLING_MODE not in DEEPSOMATIC_MODEL_TYPES:
+    raise ValueError(
+        "Invalid DeepSomatic calling_mode: "
+        f"{DEEPSOMATIC_CALLING_MODE}. "
+        "Expected 'unmatched' or 'tumor_only'."
+    )
+
+DEEPSOMATIC_CALLING_MODE_DIR = DEEPSOMATIC_CALLING_MODE_DIRS[
+    DEEPSOMATIC_CALLING_MODE
+]
+
+
+# Helper function to require the normal BAM only in unmatched mode
+def _deepsomatic_get_normal_bam(wildcards):
+    if DEEPSOMATIC_CALLING_MODE == "tumor_only":
+        return []
+    return str(rules._deepsomatic_input_normal_bam.output.bam)
+
+
+# Helper function to supply normal-specific arguments only in unmatched mode
+def _deepsomatic_get_normal_args(wildcards, input):
+    if DEEPSOMATIC_CALLING_MODE == "tumor_only":
+        return ""
+    return (
+        f'--reads_normal="{input.normal_bam}" '
+        '--sample_name_normal="NORMAL"'
+    )
+
+# Supply filters requiring the normal if calling_mode is "tumor_only"
+DEEPSOMATIC_FILTERS = CFG["options"]["filters"]
+# Helper function to supply normal filters to filtering rule depending on calling_mode
+if DEEPSOMATIC_CALLING_MODE == "tumor_only":
+    DEEPSOMATIC_NORMAL_FILTER = ""
+else:
+    DEEPSOMATIC_NORMAL_FILTER = (
+        f'&& FMT/NDP[0] >= {DEEPSOMATIC_FILTERS["normal_min_depth"]} '
+        f'&& FMT/NAF[0:1] < {DEEPSOMATIC_FILTERS["normal_max_af"]}'
+    )
+
+
+# Call variants in tumour using DeepSomatic
+rule _deepsomatic_call_variants:
+    input:
+        tumour_bam = str(rules._deepsomatic_input_bam.output.bam),
+        normal_bam = _deepsomatic_get_normal_bam,
+        fasta = reference_files("genomes/{genome_build}/genome_fasta/genome.fa"),
+        fai = reference_files("genomes/{genome_build}/genome_fasta/genome.fa.fai")
+    output:
+        vcf = CFG["dirs"]["deepsomatic_output"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/output.vcf.gz"
+    log:
+        stdout = CFG["dirs"]["deepsomatic_output"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/deepsomatic.call_variants.stdout.log",
+        stderr = CFG["dirs"]["deepsomatic_output"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/deepsomatic.call_variants.stderr.log"
+    params:
+        model_type = DEEPSOMATIC_MODEL_TYPES[DEEPSOMATIC_CALLING_MODE],
+        normal_args = _deepsomatic_get_normal_args,
+        deepsomatic_args = CFG["options"]["deepsomatic_args"],
+        intermediate_results_dir = CFG["dirs"]["deepsomatic_temp"] + "{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "--intermediate_results/",
+        logging_dir = CFG["logs"]["deepsomatic_output"] + "logs/{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR
+    container:
+        CFG["container_envs"]["deepsomatic"]
+    threads:
+        CFG["threads"]["deepsomatic"]
+    resources:
+        **CFG["resources"]["deepsomatic"]
+    shell:
+        op.as_one_line("""
+        run_deepsomatic
+            --model_type={params.model_type}
+            --ref="{input.fasta}"
+            --reads_tumor="{input.tumour_bam}"
+            {params.normal_args}
+            --output_vcf="{output.vcf}"
+            --sample_name_tumor="TUMOR"
+            --num_shards={threads}
+            --logging_dir="{params.logging_dir}"
+            --intermediate_results_dir="$(readlink -m "{params.intermediate_results_dir}")"
+            {params.deepsomatic_args}
+            > {log.stdout}
+            2> {log.stderr}
+        """)
+
+
+# Create TBI index DeepSomatic VCF file
+rule _deepsomatic_index:
+    input:
+        vcf = str(rules._deepsomatic_call_variants.output.vcf)
+    output:
+        tbi = CFG["dirs"]["deepsomatic_output"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/output.vcf.gz.tbi"
+    log:
+        stdout = CFG["dirs"]["deepsomatic_output"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/deepsomatic.index.stdout.log",
+        stderr = CFG["dirs"]["deepsomatic_output"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/deepsomatic.index.stderr.log"
+    conda:
+        CFG["conda_envs"]["bcftools"]
+    container:
+        CFG["container_envs"]["bcftools"]
+    shell:
+        op.as_one_line("""
+        tabix -p vcf {input.vcf} > {log.stdout} 2> {log.stderr}
+        """)
+
+
+# Filter out population variants and low quality variant calls
+rule _deepsomatic_filter:
+    input:
+        vcf = str(rules._deepsomatic_call_variants.output.vcf), 
+        tbi = str(rules._deepsomatic_index.output.tbi),
+        pon = reference_files("genomes/{genome_build}/ont/colorsDb.v1.2.0.deepvariant.glnexus.{genome_build}.vcf.gz")
+    output:
+        vcf = CFG["dirs"]["filter"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/output.filtered.vcf.gz",
+        tbi = CFG["dirs"]["filter"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/output.filtered.vcf.gz.tbi"
+    conda:
+        CFG["conda_envs"]["bcftools"]
+    container:
+        CFG["container_envs"]["bcftools"]
+    resources:
+        **CFG["resources"]["bcftools"]
+    threads:
+        CFG["threads"]["bcftools"]
+    log:
+        stderr = CFG["logs"]["filter"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/filter.stderr.log",
+        stdout = CFG["logs"]["filter"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/filter.stdout.log"
+    params:
+        min_depth = CFG["options"]["filters"]["min_depth"],
+        snv_min_vaf = CFG["options"]["filters"]["snv_min_vaf"],
+        snv_min_alt_depth = CFG["options"]["filters"]["snv_min_alt_depth"],
+        indel_min_vaf = CFG["options"]["filters"]["indel_min_vaf"],
+        indel_min_alt_depth = CFG["options"]["filters"]["indel_min_alt_depth"],
+        normal_filter = DEEPSOMATIC_NORMAL_FILTER
+    shell:
+        op.as_one_line("""
+        bcftools isec -C -w1 {input.vcf} {input.pon} 2> {log.stderr} |
+        bcftools view
+            -i 'FILTER="PASS" &&
+                FMT/DP[0] >= {params.min_depth} &&
+                (
+                    (TYPE="snp" && FMT/VAF[0:0] >= {params.snv_min_vaf} && FMT/AD[0:1] >= {params.snv_min_alt_depth}) ||
+                    (TYPE="indel" && FMT/VAF[0:0] >= {params.indel_min_vaf} && FMT/AD[0:1] >= {params.indel_min_alt_depth})
+                )
+                {params.normal_filter}'
+            -Oz -o {output.vcf} 2>> {log.stderr}
+        &&
+        tabix -p vcf {output.vcf} >> {log.stdout} 2>> {log.stderr}
+        """)
+
+
+# Annotates VCF file with gnomAD frequency data
+rule _deepsomatic_gnomad_annotation:
+    input:
+        vcf = str(rules._deepsomatic_filter.output.vcf),
+        tbi = str(rules._deepsomatic_filter.output.tbi),
+        gnomad = reference_files("genomes/{genome_build}/variation/af-only-gnomad.{genome_build}.vcf.gz")
+    output:
+        vcf = CFG["dirs"]["gnomad"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/output.gnomad.vcf.gz",
+        tbi = CFG["dirs"]["gnomad"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/output.gnomad.vcf.gz.tbi"
+    log:
+        stderr = CFG["logs"]["gnomad"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/gnomad.stderr.log",
+        stdout = CFG["logs"]["gnomad"] + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + "/gnomad.stdout.log"
+    conda:
+        CFG["conda_envs"]["bcftools"]
+    container:
+        CFG["container_envs"]["bcftools"]
+    threads:
+        CFG["threads"]["bcftools"]
+    resources:
+        **CFG["resources"]["bcftools"]
+    shell:
+        op.as_one_line("""
+        bcftools annotate --threads {threads} 
+        -a {input.gnomad} -c INFO/AF {input.vcf} 2> {log.stderr} |
+        awk 'BEGIN {{FS=OFS="\t"}} /^#/ {{print; next}} {{ if ($8 == ".") $8="AF=0"; else if ($8 !~ /(^|;)AF=/) $8=$8";AF=0"; print }}' |
+        bcftools view -i 'INFO/AF[0] < 0.0001' -Oz -o {output.vcf} 2>> {log.stderr}
+        &&
+        tabix -p vcf {output.vcf} >> {log.stdout} 2>> {log.stderr}
+        """)
+
+
+# Symlinks the final output files into the module results directory (under '99-outputs/')
+rule _deepsomatic_output_vcf:
+    input:
+        vcf = str(rules._deepsomatic_gnomad_annotation.output.vcf),
+        tbi = str(rules._deepsomatic_gnomad_annotation.output.tbi)
+    output:
+        vcf = CFG["dirs"]["outputs"] + "vcf/{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + ".output.final.vcf.gz",
+        tbi = CFG["dirs"]["outputs"] + "vcf/{seq_type}--{genome_build}/{tumour_id}--{normal_name}--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR + ".output.final.vcf.gz.tbi"
+    run:
+        op.relative_symlink(input.vcf, output.vcf, in_module= True)
+        op.relative_symlink(input.tbi, output.tbi, in_module= True)
+
+
+# Remove files from the intermediate_results_dir used during DeepSomatic
+rule _cleanup_intermediate_dir:
+    input:
+        vcf = str(rules._deepsomatic_output_vcf.output.vcf),
+        tbi = str(rules._deepsomatic_output_vcf.output.tbi)
+    output:
+        cleanup_dummy = touch(
+            CFG["dirs"]["deepsomatic_output"]
+            + "{seq_type}--{genome_build}/{tumour_id}--{normal_name}"
+            + "--{chemistry}--" + DEEPSOMATIC_CALLING_MODE_DIR
+            + "/cleanup_complete.txt"
+        )
+    params:
+        cleanup_toggle = CFG["options"]["cleanup_toggle"],
+        intermediate_results_parent = CFG["dirs"]["deepsomatic_temp"],
+        intermediate_results_dir = (
+            CFG["dirs"]["deepsomatic_temp"]
+            + "{tumour_id}--{normal_name}--{chemistry}--"
+            + DEEPSOMATIC_CALLING_MODE_DIR
+            + "--intermediate_results/"
+        )
+    shell:
+        op.as_one_line("""
+        if [[ "{params.cleanup_toggle}" == "True" ]]; then
+            target=$(readlink -f "{params.intermediate_results_dir}" 2>/dev/null || true) ;
+            parent=$(readlink -f "{params.intermediate_results_parent}" 2>/dev/null || true) ;
+            if [[ -n "$target" &&
+                  -n "$parent" &&
+                  "$target" != "/" &&
+                  "$target" == "$parent"/* ]]; then
+                rm -rf -- "$target" ;
+            elif [[ -n "$target" ]]; then
+                echo "Refusing to remove unexpected path: $target" >&2 ;
+                exit 1 ;
+            fi ;
+            if [[ -L "{params.intermediate_results_dir}" ]]; then
+                rm -f -- "{params.intermediate_results_dir}" ;
+            fi ;
+        else
+            echo "Skipping cleanup" ;
+        fi
+        """)
+
+
+# Generates the target sentinels for each run, which generate the symlinks
+rule _deepsomatic_all:
+    input:
+        expand(
+            [
+                str(rules._deepsomatic_output_vcf.output.vcf),
+                str(rules._deepsomatic_output_vcf.output.tbi),
+                str(rules._cleanup_intermediate_dir.output.cleanup_dummy)
+            ],
+            zip,
+            seq_type=CFG["runs"]["tumour_seq_type"],
+            genome_build=CFG["runs"]["tumour_genome_build"],
+            tumour_id=CFG["runs"]["tumour_sample_id"],
+            pair_status=CFG["runs"]["pair_status"],
+            chemistry=CFG["runs"]["tumour_chemistry"],
+            normal_name=CFG["runs"]["normal_name"]
+        )
+
+
+##### CLEANUP #####
+
+
+# Perform some clean-up tasks, including storing the module-specific
+# configuration on disk and deleting the `CFG` variable
+op.cleanup_module(CFG)

--- a/modules/deepsomatic/1.0/deepsomatic.smk
+++ b/modules/deepsomatic/1.0/deepsomatic.smk
@@ -238,6 +238,10 @@ rule _deepsomatic_index:
         CFG["conda_envs"]["bcftools"]
     container:
         CFG["container_envs"]["bcftools"]
+    resources:
+        **CFG["resources"]["bcftools"]
+    threads:
+        CFG["threads"]["bcftools"]
     shell:
         op.as_one_line("""
         tabix -p vcf {input.vcf} > {log.stdout} 2> {log.stderr}

--- a/modules/deepsomatic/1.0/envs/bcftools-1.10.2.yaml
+++ b/modules/deepsomatic/1.0/envs/bcftools-1.10.2.yaml
@@ -1,0 +1,1 @@
+../../../../envs/bcftools/bcftools-1.10.2.yaml

--- a/modules/deepsomatic/1.0/schemas/base-1.0.yaml
+++ b/modules/deepsomatic/1.0/schemas/base-1.0.yaml
@@ -1,0 +1,1 @@
+../../../../schemas/base/base-1.0.yaml

--- a/modules/deepsomatic/1.0/schemas/chemistry-1.0.yaml
+++ b/modules/deepsomatic/1.0/schemas/chemistry-1.0.yaml
@@ -1,0 +1,1 @@
+../../../../schemas/ont/chemistry-1.0.yaml

--- a/modules/deepsomatic/CHANGELOG.md
+++ b/modules/deepsomatic/CHANGELOG.md
@@ -1,0 +1,33 @@
+
+# Changelog
+
+All notable changes to the `deepsomatic` module will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0] - 2026-08-10
+
+This release was authored by Giuliano Banco.
+
+Initial release of the `deepsomatic` module, which calls somatic variants from Oxford
+Nanopore Technologies (ONT) long-read data using DeepSomatic. The workflow calls variants,
+indexes the VCF with tabix, filters against a panel of normals and quality/depth/VAF
+thresholds, annotates with gnomAD population frequencies, and symlinks a final filtered
+VCF into the outputs directory.
+
+### Requirements and constraints
+- Requires a sample table with `chemistry` and `platform` columns (enforced by schemas).
+- Only compatible with PromethION and hg38 data as of version 1.0.
+- Requires container usage for the DeepSomatic calling step. The bcftools steps (index,
+    filter, gnomAD annotation) support either conda or container.
+
+### Features
+- Two calling modes, set via `calling_mode` in the config.
+    - `unmatched` (uses an unmatched normal BAM with the ONT model)
+    - `tumor_only` (no normal, ONT_TUMOR_ONLY model). Normal-based filters are only
+        applied in unmatched mode.
+- Maps tumour chemistry (R9 or R10) to a normal sample name via the `normal_name`
+    config option.
+- Filters variants to gnomAD AF < 0.0001 (missing AF is treated as 0).
+- Optional cleanup of DeepSomatic intermediate files with `cleanup_toggle` (recommended).


### PR DESCRIPTION
# Pull Request Checklists

**Important:** When opening a pull request, keep only the applicable checklist and delete all other sections.

## Checklist for New Module

### Required

- [x] I used the cookiecutter template and updated the placeholder rules.

- [x] The snakemake rules follow the [design guidelines](https://lcr-modules.readthedocs.io/en/latest/for_developers.html#module-rules).

  - [x] All references to the `rules` object (_e.g._ for input files) are wrapped with `str()`.

- [x] Every rule in the module is either listed under `localrules` or has the `threads` and `resources` directives.

- [x] Input and output files are being symlinked into the `CFG["inputs"]` and `CFG["outputs"]` subdirectories, respectively.

- [ ] I grouped the input symlinking rule to the next job that uses the input files. **Instead of doing this, I have input rules as local rules**

- [x] I updated the final target rule (`*_all`) to include every output rule.

- [x] I explained important module design decisions in `CHANGELOG.md`.

- [x] I tested the module on real data for all supported `seq_type` values.

- [x] I updated the `default.yaml` configuration file to provide default values for each rule in the module snakefile.

- [x] I did not set any global wildcard constraints. Any/all wildcard constraints are set on a per-rule basis.

- [x] I ensured that all symbolic links are relative and self-contained (_i.e._ do not point outside of the repository).

- [x] I replaced every value that should (or might need to) be updated in the default configuration file with `__UPDATE__`.

- [x] I recursively searched for all comments containing `TODO` to ensure none were left. For example:

  ```bash
  grep -r TODO modules/<module_name>/1.0
  ```

### If applicable

- [x] I added more granular output subdirectories.

- [ ] I added rules to the `reference_files` workflow to generate any new reference files.

- [x] I added subdirectories with large intermediate files to the list of `scratch_subdirectories` in the `default.yaml` configuration file.

- [x] I updated the list of available wildcards for the input files in the `default.yaml` configuration file.
