### PR TITLE
Add . before bai extension in input rule

### DIFF
--- a/modules/sniffles/1.1/sniffles.smk
+++ b/modules/sniffles/1.1/sniffles.smk
@@ -53,7 +53,7 @@ localrules:
 rule _promethion_bam:
     input:
         bam = CFG["inputs"]["sample_bam"],
-        bai = CFG["inputs"]["sample_bam"] + "bai"
+        bai = CFG["inputs"]["sample_bam"] + ".bai"
     output:
         bam = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam",
         bai = CFG["dirs"]["inputs"] + "bam/{seq_type}--{genome_build}/{sample_id}.bam.bai",


### PR DESCRIPTION
Very minor PR to fix an issue with the .bai input in the input rule.